### PR TITLE
fix: add missing prompt assignment in local dataset branch

### DIFF
--- a/src/qflux/data/dataset.py
+++ b/src/qflux/data/dataset.py
@@ -511,6 +511,7 @@ class ImageDataset(Dataset):
             if self.data_key_exist(data_item, "caption") and data_item["dataset_type"] == "local":
                 with open(data_item["caption"], encoding="utf-8") as f:
                     prompt = f.read().strip()
+                data["prompt"] = prompt
             else:
                 prompt = data_item["caption"]
                 data["prompt"] = prompt


### PR DESCRIPTION
## 🐛 Bug Description

When loading local datasets in `load_data()`, the prompt text is read from the caption file but not assigned to `data["prompt"]`. This causes a `KeyError: 'prompt'` during training when `prepare_embeddings()` tries to access the prompt.

```[rank0]: Traceback (most recent call last):
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/main.py", line 99, in <module>
[rank0]:     main()
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/main.py", line 95, in main
[rank0]:     trainer.fit(train_dataloader)
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/trainer/base_trainer.py", line 648, in fit
[rank0]:     self.train_epoch(epoch, train_dataloader)
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/trainer/base_trainer.py", line 522, in train_epoch
[rank0]:     loss = self.training_step(batch)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/trainer/base_trainer.py", line 461, in training_step
[rank0]:     return self._training_step_compute(batch)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/trainer/base_trainer.py", line 470, in _training_step_compute
[rank0]:     embeddings = self.prepare_embeddings(batch, stage="fit")
[rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/AIGC_Group/qwen-image-finetune/src/qflux/trainer/qwen_image_edit_trainer.py", line 419, in prepare_embeddings
[rank0]:     prompt=batch["prompt"],
[rank0]:            ~~~~~^^^^^^^^^^
[rank0]: KeyError: 'prompt'
```

**Error Traceback:**
```
KeyError: 'prompt'
  File "qflux/trainer/qwen_image_edit_trainer.py", line 419, in prepare_embeddings
    prompt=batch["prompt"],
```

## 🔍 Root Cause

In the local dataset branch of `load_data()`:
```python
# Before (buggy code)
if self.data_key_exist(data_item, "caption") and data_item["dataset_type"] == "local":
    with open(data_item["caption"], encoding="utf-8") as f:
        prompt = f.read().strip()
    # ❌ Missing: data["prompt"] = prompt
else:
    prompt = data_item["caption"]
    data["prompt"] = prompt  # Only set in else branch
```

The prompt variable is populated but never added to the `data` dictionary in the `if` branch.

## ✅ Solution

Add the missing assignment in the `if` branch:
```python
# After (fixed code)
if self.data_key_exist(data_item, "caption") and data_item["dataset_type"] == "local":
    with open(data_item["caption"], encoding="utf-8") as f:
        prompt = f.read().strip()
    data["prompt"] = prompt  # ✅ Added
else:
    prompt = data_item["caption"]
    data["prompt"] = prompt
```

## Summary by Sourcery

Bug Fixes:
- Set the prompt field on data records loaded from local datasets so training code can reliably access batch["prompt"].