### PR TITLE
Add Agent skill for Intel AI PC NF4 QLoRA fine-tuning on Qwen-Image-Edit

### DIFF
--- a/.claude/skills/qwen-image-edit-aipc-finetune/README.md
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/README.md
@@ -1,0 +1,81 @@
+# Qwen-Image-Edit Fine-Tune on Intel AI PC — Quick Start
+
+A Claude Code skill for fine-tuning **Qwen-Image-Edit** with **NF4 QLoRA**
+on an Intel AI PC (Core Ultra processor) Windows laptop.
+
+This skill is consumed by an **agent** (Claude Code or compatible) acting
+on your behalf. The agent reads `SKILL.md` and walks you through every
+step interactively — including the human-only pre-flight (driver,
+oneAPI, conda, etc.).
+
+## How to use this skill
+
+1. **Clone the framework** (original CUDA-only version) to a local directory:
+
+   ```bat
+   git clone --no-checkout https://github.com/tsiendragon/qwen-image-finetune <local-path>
+   cd <local-path>
+   git checkout main -- . ":(exclude)docs/plan/v1.6.0:sampling_during_train.md" ":(exclude)tests/src/trainer/ /"
+   ```
+
+   > **Why not a plain `git clone`?** The upstream repository contains two files
+   > with Windows-incompatible names (a colon and a space-only directory). A plain
+   > `git clone` fails the checkout entirely and leaves the working tree empty.
+   > The commands above use git's `:(exclude)` pathspec to skip those two paths.
+   >
+   > After cloning, `git status` will show those two paths as `deleted` — this is
+   > expected and does not affect the training workflow. If the upstream repository
+   > removes those files, the `:(exclude)` patterns simply match nothing and all
+   > files are checked out normally.
+
+   This is the unmodified upstream repo. The agent will apply all XPU
+   adaptations (§6 of `SKILL.md`) during setup.
+
+2. **Open your agent (Claude Code, etc.) inside that directory** and make
+   sure it has this skill available — usually by placing the skill folder
+   under `.claude/skills/` or per your agent's skill-source configuration.
+
+3. **Ask the agent for help**, for example:
+
+   > "I have a Core Ultra AI PC and want to fine-tune Qwen-Image-Edit
+   > with LoRA on my own dataset."
+
+   The agent loads `SKILL.md` and walks you through everything else.
+   First-time setup requires working through several installers and
+   downloading large model files; subsequent runs reuse the result.
+
+## What you'll do versus what the agent does
+
+The agent will guide you through each item, but here's the rough split:
+
+- **You (one-time, hands-on)**: Intel Arc driver install · Miniforge /
+  conda install · Visual Studio Community + C++ workload · Intel oneAPI
+  Base Toolkit · Windows long-path registry tweak · GPU shared-memory
+  registry tweak · model + dataset on disk ·
+  visual inspection of training results.
+- **The agent**: hardware probe · training config recommendation · conda
+  env creation · `torch+xpu` install · framework XPU adaptations · NF4
+  pre-quantization · cache build · training launch · inference image
+  generation (base + LoRA) for your review.
+
+## Skill contents
+
+- `SKILL.md` — the agent's full runbook (11 sections). Don't edit unless
+  maintaining the skill.
+- `templates/` — scripts the agent invokes:
+  - `probe_hw.py` + `recommend_config.py` — hardware-tiered config
+  - `quantize_transformer_nf4.py` + `quantize_text_encoder_nf4.py` — one-time NF4 pre-quantization (DiT and text_encoder)
+  - `dataset_validate.py` — dataset sanity check
+  - `inference_compare.py` — post-training visual comparison (base vs LoRA)
+  - `monitor_xpu_memory.py` — XPU memory monitor for training / inference
+  - `launchers/quantize_xpu.bat` — Windows launcher for transformer NF4 quantization
+  - `launchers/quantize_text_encoder_xpu.bat` — Windows launcher for text_encoder NF4 quantization
+  - `launchers/train_xpu.bat` — Windows launcher for training (cache + fit)
+
+
+## When something goes wrong
+
+`SKILL.md` §10 covers known XPU-on-Windows issues with fixes (Triton
+cache staleness, DataLoader pickling, `accelerator.device` selecting
+the wrong device, dataset-split errors, cache-phase OOM, etc.). The
+agent will reach for §10 entries automatically as symptoms appear.

--- a/.claude/skills/qwen-image-edit-aipc-finetune/README.md
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/README.md
@@ -31,9 +31,10 @@ oneAPI, conda, etc.).
    This is the unmodified upstream repo. The agent will apply all XPU
    adaptations (§6 of `SKILL.md`) during setup.
 
-2. **Open your agent (Claude Code, etc.) inside that directory** and make
-   sure it has this skill available — usually by placing the skill folder
-   under `.claude/skills/` or per your agent's skill-source configuration.
+2. **Open your agent (Claude Code, etc.) inside that directory.** This skill
+   is pre-installed in `.claude/skills/` of the repository — no extra setup
+   needed. If you are using the skill from a separate source, place this
+   directory under `.claude/skills/` in your project.
 
 3. **Ask the agent for help**, for example:
 

--- a/.claude/skills/qwen-image-edit-aipc-finetune/SKILL.md
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/SKILL.md
@@ -2,12 +2,13 @@
 name: qwen-image-edit-aipc-finetune
 description: >
   End-to-end runbook for fine-tuning Qwen-Image-Edit with LoRA on a single Intel
-  AI PC (Core Ultra processor) Windows laptop. Use this skill when a user wants
-  to personalize Qwen-Image-Edit on their own dataset using consumer-grade Intel
-  AI PC hardware. Covers: dataset preparation guidance, hardware probe →
-  recommended training config, oneAPI / conda environment setup, NF4 QLoRA
-  memory optimizations, training execution, programmatic LoRA quality
-  validation.
+  AI PC (Core Ultra processor) Windows laptop. Use this skill whenever a user
+  wants to fine-tune or personalize Qwen-Image-Edit on their own dataset using
+  Intel AI PC hardware, mentions XPU training or NF4 QLoRA on Windows — even if
+  they don't use those exact terms. Covers: dataset preparation, hardware probe
+  → recommended training config, oneAPI / conda environment setup, XPU framework
+  adaptation, NF4 QLoRA memory optimizations, training execution, and
+  post-training visual comparison.
 ---
 
 # Qwen-Image-Edit LoRA Fine-Tuning on Intel AI PC (Windows)

--- a/.claude/skills/qwen-image-edit-aipc-finetune/SKILL.md
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/SKILL.md
@@ -1,0 +1,1530 @@
+---
+name: qwen-image-edit-aipc-finetune
+description: >
+  End-to-end runbook for fine-tuning Qwen-Image-Edit with LoRA on a single Intel
+  AI PC (Core Ultra processor) Windows laptop. Use this skill when a user wants
+  to personalize Qwen-Image-Edit on their own dataset using consumer-grade Intel
+  AI PC hardware. Covers: dataset preparation guidance, hardware probe →
+  recommended training config, oneAPI / conda environment setup, NF4 QLoRA
+  memory optimizations, training execution, programmatic LoRA quality
+  validation.
+---
+
+# Qwen-Image-Edit LoRA Fine-Tuning on Intel AI PC (Windows)
+
+## 1. Background & Scope
+
+This skill is the end-to-end runbook for fine-tuning **Qwen-Image-Edit** with
+LoRA on a single Intel AI PC (Core Ultra processor) Windows laptop. It is
+written to be consumed by an agent acting on behalf of a non-expert user.
+
+**Scope**: this skill targets **NF4 QLoRA only**. Other recipes (bf16 /
+fp16 LoRA, full fine-tuning, etc.) are out of scope — 4-bit quantization
+of the transformer is what makes the workload fit on AI PC unified memory.
+
+**Recipe**: NF4-quantized transformer + LoRA +
+`bitsandbytes.optim.Adam8bit` + cache-first workflow + mode-aware component
+loading. Single-card XPU training under `accelerate launch` with
+`distributed_type: NO` and `mixed_precision: 'no'`. The recommender (§5)
+selects a sensible default config matched to AI PC hardware, with RAM-tier
+adjustments where applicable.
+
+**Workflow**: §2 human pre-flight → §3 dataset prep → §4 conda env →
+§5 hardware probe + recommended config → §6 framework adaptation →
+§7 conditional memory optimizations → §8 training → §9 validation.
+§11 walks the full sequence with PASS signals at each step.
+
+The skill assumes the user has already cloned `qwen-image-finetune`. The
+agent walks them through §6 to apply XPU adaptations to the clone — these
+are not auto-applied. After §6, the rest is largely automatable.
+
+## 2. Pre-flight (human prerequisites)
+
+The agent **cannot** complete the items below unattended. The user works
+through them once before signaling the agent to proceed at §3. Order matters
+where noted (e.g., Visual Studio is a prerequisite for oneAPI).
+
+### 2.1 Hardware sanity
+
+- Intel AI PC with **Core Ultra** processor and Intel iGPU.
+
+### 2.2 Disk space
+
+The estimates below cover **training-related components only** (model, data,
+outputs, conda env). Prerequisite tools required by §2 (Intel Arc driver,
+Intel oneAPI Base Toolkit, Visual Studio, etc.) need additional space on top
+of this — consult their respective installers for current sizes.
+
+Estimate at minimum **~65 GB free** on the target drive for training
+components; **~80 GB** if both NF4 pre-quantizations (§7.1 + §7.2) are
+performed. Sizes below are as displayed in Windows File Explorer (binary,
+GiB — e.g. Windows shows a 9.82 GiB file as "9.82 GB"):
+
+| Item | Approx. size |
+|---|---|
+| Qwen-Image-Edit model repository (the original, unmodified) | ~54 GB |
+| NF4-quantized transformer output (§7.1, optional) | ~10 GB |
+| NF4-quantized text encoder output (§7.2, optional) | ~5.5 GB |
+| Dataset (depends on yours; character-composition reference is small) | ~1-5 GB |
+| Embedding cache (proportional to dataset size) | ~0.5 MB/sample (e.g. ~18 MB for 35 samples) |
+| Training checkpoints (LoRA adapters only; lightweight) | ~50 MB × N checkpoints |
+| Conda env | ~6 GB |
+
+### 2.3 Windows registry settings (admin Command Prompt)
+
+Two registry tweaks make AI PC fine-tuning materially smoother. Open an
+**admin Command Prompt** (right-click Start → "Terminal (Admin)" or search
+"cmd" and run as administrator):
+
+**Long-path support** — model file paths can exceed Windows' 260-char limit:
+
+```bat
+powershell -Command "Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1"
+```
+
+**Shared GPU memory ceiling** — AI PC iGPUs use unified memory; raising this
+ceiling lets the OS commit more memory to the GPU process during the NF4 cache
+phase. Open Registry Editor (Win+R → `regedit`), navigate to:
+
+```
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\MemoryManager
+```
+
+Change `SystemPartitionCommitLimitPercentage` to a higher value (e.g. **75**
+from the default ~57). Reboot for both changes to take effect.
+
+### 2.4 Intel GPU driver
+
+Install the latest Intel Arc Graphics driver:
+
+https://www.intel.com/content/www/us/en/download/785597/intel-arc-graphics-windows.html
+
+Verify after install: Windows Device Manager → Display adapters → "Intel
+Arc Graphics" appears without warnings.
+
+### 2.5 Conda / Python
+
+Install Miniforge from conda-forge:
+
+https://conda-forge.org/download/
+
+Confirm `conda --version` works in CMD after install (may require new shell
+session).
+
+### 2.6 Visual Studio Community (oneAPI prerequisite)
+
+Required to provide the C++ build toolchain that oneAPI uses for Triton
+JIT kernel compilation:
+
+https://visualstudio.microsoft.com/vs/community/
+
+During install, check the **"Desktop development with C++"** workload.
+Other workloads are not required.
+
+### 2.7 Intel oneAPI Base Toolkit
+
+Required for bitsandbytes Triton-backed XPU kernels (NF4 quantize on first
+load, `Adam8bit.step()` every step). Install **after** §2.6 (oneAPI's
+installer detects the C++ toolchain).
+
+Match the oneAPI version to the `torch+xpu` version you plan to install
+in §4:
+
+| `torch+xpu` | Triton package | oneAPI version |
+|---|---|---|
+| `2.9.0+xpu` | `pytorch-triton-xpu` 3.5 | 2025.2 |
+| `2.10.0+xpu` | `triton-xpu` 3.6 | 2025.3 |
+| `2.11.0+xpu` | `triton-xpu` 3.7 | 2025.3 |
+| `2.12.0+xpu` | `triton-xpu` 3.7.1 | 2025.3 |
+
+Download from:
+
+https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html
+
+Default install path: `C:\Program Files (x86)\Intel\oneAPI`. The training
+launcher (`templates/launchers/train_xpu.bat`) invokes `setvars.bat` from
+this path; if you install elsewhere, update the launcher.
+
+> **If your `torch+xpu` version isn't listed above** (e.g. pip pulls a
+> newer release than this skill anticipates): infer the matching oneAPI
+> from pip's installed Intel transitive dependencies. Complete §2.4
+> (conda) + §4.1-§4.2 first (create env + `pip install torch --index-url
+> https://download.pytorch.org/whl/xpu`), then in the activated env run:
+>
+> ```bat
+> pip list | findstr /I "intel- onemkl-sycl-"
+> ```
+>
+> The major version of the `intel-*` and `onemkl-sycl-*` packages tells
+> you which oneAPI release to install (e.g. seeing `2025.3.x` → install
+> Intel oneAPI Base Toolkit **2025.3**). After oneAPI installs, return to
+> §4.3 to install the remaining project dependencies.
+
+**Already have oneAPI installed?** If oneAPI is already on your machine,
+consider installing the `torch+xpu` version that matches your existing oneAPI
+rather than upgrading oneAPI. Check which oneAPI version you have (see below),
+then install the corresponding `torch+xpu` in §4.2 — this is often less work
+than reinstalling oneAPI.
+
+Verify after install (fresh CMD):
+
+```bat
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+where icpx
+icpx --version
+```
+
+`where icpx` must print a real path. To read the exact toolkit version (e.g.
+`2025.3`), look at the `InstalledDir` line in the `icpx --version` output —
+the version directory in the path is the toolkit version:
+
+```
+InstalledDir: C:\Program Files (x86)\Intel\oneAPI\compiler\2025.3\bin\compiler
+                                                           ^^^^^
+                                             this is the toolkit version
+```
+
+(`icpx --version` also prints `Compiler 2025.3.3 ...` — note the three-part
+compiler build version may differ slightly from the two-part toolkit version
+`2025.3` in the path. Use the path number to match against the §2.7 table.)
+
+Alternatively, open `C:\Program Files (x86)\Intel\oneAPI\Installer\installer.exe`
+to see the installed toolkit version in the UI.
+
+If `setvars.bat` reports `'vars.bat' is not recognized`, see §10.
+
+### 2.8 Download Qwen-Image-Edit model
+
+Qwen-Image-Edit is an open model — no HuggingFace account or token is required.
+Download to a local directory that the agent will use as
+`pretrained_model_name_or_path` (~54 GB):
+
+```bat
+huggingface-cli download Qwen/Qwen-Image-Edit-2511 --local-dir <path\to\model>
+```
+
+(https://huggingface.co/Qwen/Qwen-Image-Edit-2511)
+
+Earlier versions of Qwen-Image-Edit (e.g., Qwen-Image-Edit-2509) should also
+work with this skill in principle; replace the repo ID and local-dir path
+accordingly.
+
+### 2.9 Pre-flight checklist
+
+Confirm each item before signaling the agent to proceed:
+
+- [ ] AI PC with Core Ultra processor confirmed
+- [ ] ≥ 80 GB free disk space on target drive
+- [ ] Long-path registry enabled; GPU shared memory ceiling adjusted; reboot done
+- [ ] Intel Arc Graphics driver installed (Device Manager shows iGPU clean)
+- [ ] conda installed (`conda --version` works)
+- [ ] Visual Studio Community installed with "Desktop development with C++" workload
+- [ ] Intel oneAPI Base Toolkit installed (`where icpx` works in a fresh CMD after `setvars.bat`)
+- [ ] Qwen-Image-Edit model downloaded to a local directory
+- [ ] `qwen-image-finetune` project cloned to a local directory
+- [ ] Training dataset prepared per §3 (or ready to be prepared at §3)
+
+## 3. Dataset Preparation
+
+The qwen-image-finetune framework (`qflux.data.dataset.ImageDataset`) supports
+three dataset formats. Pick whichever fits the user's workflow; all three are
+validated by `templates/dataset_validate.py`.
+
+### 3.1 Format options
+
+| Format | When to use | Schema |
+|---|---|---|
+| **Local directory** | Quick iteration on a custom dataset | Stem-paired files: `<stem>.png` (target) + `<stem>.png` (control) + `<stem>.txt` (prompt), under `training_images/` and `control_images/` subdirs |
+| **HuggingFace dataset** | Sharing / public datasets | Repo or local parquet dir; columns: `target_image`, `control_images` (list), `prompt`, optional `control_mask` |
+| **CSV** | Migrating from another pipeline | Columns: `path_target`, `path_control` (one or more `path_control_N`), `prompt`, optional `path_mask` |
+
+Detailed schemas live in `src/qflux/data/dataset.py` (`ImageDataset.__init__`
+docstring). The §5 recommender emits a `data:` block matching whichever format
+the user has.
+
+### 3.2 Local directory layout
+
+```
+dataset_root/
+├── training_images/
+│   ├── sampleA.png              # target image — the desired OUTPUT after the edit
+│   └── sampleA.txt              # required: prompt text (the edit instruction)
+└── control_images/
+    ├── sampleA.png              # main control — INPUT condition (e.g. background scene)
+    ├── sampleA_control_1.png    # optional: 2nd control (e.g. character reference image)
+    └── sampleA_mask.png         # optional: mask of the edited region (character silhouette)
+```
+
+**Naming rules** (from `qflux.data.dataset.ImageDataset` documentation):
+- Extra control images: append `_control_1`, `_control_2`, … to the base name
+- Mask: `<base>_mask.png` in either `control_images/` or `training_images/`
+- Prompt: `.txt` file with the same base name; if present in both dirs, `training_images/` wins
+
+**Alternative directory names** accepted: `images` / `target_images` / `target` for targets; `control` / `condition_images` / `controls` for controls.
+
+**Multi-control example** (character composition task): `sampleA.png` = background scene, `sampleA_control_1.png` = character on white background, `sampleA_mask.png` = character silhouette in the final composition, prompt = "Add the character to the image". This is the pattern used by the `TsienDragon/character-composition` reference dataset.
+
+**Mask usage**: when a mask is present, `edit_mask_loss` applies higher training weight to the masked region, focusing the LoRA on the area that changed between control and target. Useful when only part of the image is edited.
+
+### 3.3 Sample size guidance
+
+| Sample count | Expected outcome |
+|---|---|
+| < 5 | Hard floor — `dataset_validate.py` rejects; too few to cache meaningfully |
+| 5–19 | Smoke test only; rapid overfitting expected within the first tens of steps |
+| 20–50 | **Practical starting point for a narrow task** (single subject, single edit type, single viewpoint set). Community experience confirms this range works for specific character/product LoRAs. ² |
+| 50–100 | Better generalization; recommended if the edit should work across varying scenes or lighting. A 50-image rendered dataset has been validated for complex spatial transformations. ³ |
+| 100–200+ | For more general edit styles that should work across many different scenes and subjects. ² |
+
+**Quality beats quantity.** Adding low-quality or inconsistent pairs actively harms the LoRA — they introduce noise the model cannot learn a clean pattern from. ¹ ²
+
+**Single-task LoRA preferred.** If you want to train multiple distinct edits (e.g., style + object replacement), train separate LoRAs rather than one mixed dataset. Multi-task LoRA often causes the tasks to interfere with each other. ²
+
+`templates/dataset_validate.py` enforces the floor of 5 samples and warns below 30. The framework caches embeddings per-sample (§7.4), so larger datasets cost more upfront cache time but no extra per-step cost during fit.
+
+---
+¹ FlyMyAI LoRA Trainer, https://github.com/FlyMyAI/flymyai-lora-trainer, Aug 2025. Uses a different training framework; cited for model-level image quality guidance applicable to Qwen-Image-Edit.  
+² HuggingFace Forums: "Question about lora fine tune qwen-image-edit" (John6666, Nov 2025), https://discuss.huggingface.co/t/question-about-lora-fine-tune-qwen-image-edit/170633. Qwen-Image-Edit-specific community guidance; cited for dataset size ranges, quality advice, and single-task LoRA recommendation.  
+³ とりにく, "vast.AIでQwen image Edit 2509のLoRA学習", https://note.com/tori29umai/n/n256f30d51669, Sept 2025. Uses Musubi Tuner (a separate training framework); dataset construction and spatial transformation advice is model-level and framework-independent.
+
+### 3.4 Control image and target image — the edit pair
+
+Qwen-Image-Edit is an **image editing** model, not an image generation model. Every training sample teaches the model one specific edit:
+
+| Part | Role | Example |
+|---|---|---|
+| **Control image(s)** | The input condition(s) — what the user provides | Background scene, character reference, source style |
+| **Target image** | The desired output — what the model should produce | The same scene after the edit is applied |
+| **Prompt** | The edit instruction | "Add the character to the image" |
+
+The key difference from caption-based LoRA training (e.g. for image generation): the prompt describes **what to do**, not **what the result looks like**.
+
+**Multi-control paradigm** — the framework natively supports multiple control images per sample, which is useful when the edit requires more than one reference:
+- Main control (`sampleA.png`): the primary input scene or reference
+- Additional controls (`sampleA_control_1.png`, `_control_2.png`, …): supplementary references (e.g. a character sheet, a style reference)
+- Mask (`sampleA_mask.png`): region of interest — tells the model which part of the image the edit targets
+
+**Verified example** (character-composition task): the `TsienDragon/character-composition` dataset is one verified instance of this setup — it uses two controls (a background image and a character-on-white-background image) plus a mask of the character's silhouette, with a fixed prompt "Add the character to the image". The target is the character correctly composited into the background. User-created datasets following the same format work equally well.
+
+**General task examples** (for reference, not exhaustive):
+- *Viewpoint change*: control = source angle; target = desired angle; prompt = describe the viewpoint transformation ³
+- *Object addition*: control = scene; target = scene with object added; prompt = "Add [object] to the image"
+- *Style change*: control = original; target = restyled; prompt = describe the style change
+
+**Important**: control and target must share the same subject/context. Unrelated images in a pair prevent the model from learning a coherent edit mapping.
+
+**Practical tip**: synthetic or rendered control images (e.g. 3D, game engine) produce very consistent results because they eliminate photographic variation that the model might otherwise try to replicate. ³
+
+---
+³ とりにく, "vast.AIでQwen image Edit 2509のLoRA学習", https://note.com/tori29umai/n/n256f30d51669, Sept 2025. Uses Musubi Tuner (a separate training framework); dataset construction advice is model-level and framework-independent.
+
+### 3.5 Image quality guidelines
+
+- **Resolution**: source images should be **at least as large as your `target_size`** in each dimension. The training preprocessor crops/resizes source images down to `target_size` — if the source is smaller, it gets upscaled first (quality loss). Practical guide by training tier:
+  - `target_size [384, 672]` (default): source images ≥ 672px in the longer dimension. 512px+ short-side is fine.
+  - `target_size [512, 768]`: source images ≥ 768px in the longer dimension. 512×512 would require upscaling and is not ideal.
+  - Higher source resolution than your `target_size` is always fine; the crop just has more to choose from.
+  *(Recommended range from `docs/guide/data-preparation.md`: 512×512 to 1024×1024 — this is appropriate for the default `target_size [384, 672]` and most configurations used with this skill.)*
+- **Format**: JPG, JPEG, PNG, WebP — all supported by the framework. RGB (3-channel) required.
+- **Consistency within dataset**: maintain consistent image quality, lighting style, and subject framing across pairs. Inconsistency is a common cause of blurry or incoherent model outputs. ¹
+- **Quality over quantity**: more low-quality pairs actively harm the LoRA — they introduce noise the model cannot learn a clean pattern from. ¹
+- **Avoid**: watermarks or text overlays in control/target images; heavy JPEG artefacts; mixing very different visual styles (e.g., anime and photorealistic) in the same dataset without a compelling reason.
+
+---
+¹ FlyMyAI LoRA Trainer, https://github.com/FlyMyAI/flymyai-lora-trainer, Aug 2025. Uses a different training framework; cited for model-level image quality guidance applicable to Qwen-Image-Edit.
+
+### 3.6 Prompt strategy
+
+The framework expects prompts to be **descriptive editing instructions** — text that tells the model what to do, not what the result looks like.  
+*(From `docs/guide/data-preparation.md`: "Descriptive editing instructions"; recommended length 10–200 words)*
+
+| Prompt type | Example | Use |
+|---|---|---|
+| **Edit instruction** (correct) | "Add the character to the image" | For image editing LoRA training |
+| **Target image caption** (incorrect for editing) | "A character standing in a room" | Trains the model to generate, not edit |
+
+**Key guidelines:**
+
+- **Describe the transformation**: "Add the character to the image" teaches *what to do* (placement); "A character in a room" only describes *what exists* in the result — the model cannot learn the editing operation from it.
+- **Consistency within a dataset**: if all samples share the same edit type (e.g., character composition), a fixed or near-fixed prompt like "Add the character to the image" is valid and has been shown to work well. The model learns the edit from the image pairs; the prompt anchors what operation is being requested.
+- **Specificity when edits vary**: if your dataset covers multiple edit types or subjects, prompts should distinguish them — e.g. "Add the character to the outdoor scene" vs "Add the character to the interior scene" — so the model learns to condition on the instruction, not just pattern-match visually.
+- **Length**: 10–200 words accepted by the framework. Short, clear instructions work well for specific tasks; longer prompts are appropriate when the edit is complex or context-dependent.
+- **Avoid ambiguity**: "Edit the image" teaches nothing — a prompt must specify what kind of edit.
+
+### 3.7 Validation step
+
+Before committing to a training run, validate the dataset:
+
+```bash
+python templates/dataset_validate.py <path>
+# Local dir:    python templates/dataset_validate.py <path/to/dataset>
+# HF parquet:   python templates/dataset_validate.py <path/to/parquet-dir>
+# CSV:          python templates/dataset_validate.py <path/to/dataset.csv>
+```
+
+JSON verdict format:
+```json
+{
+  "valid": true,
+  "format": "local",
+  "sample_count": 35,
+  "issues": [],
+  "warnings": []
+}
+```
+
+Exit code 0 = valid (proceed to §4); 1 = invalid (fix before proceeding).
+Issues are blockers; warnings are advisory (e.g., small sample count fine for
+smoke test, problematic for real training).
+
+Common issues caught: missing `training_images/` or `control_images/` subdir;
+target images without matching control or prompt; sample count too low.
+
+**Manual check after the script passes** — `dataset_validate.py` only checks
+format and structure; it cannot verify semantic correctness. Before starting
+a full training run, inspect 3–5 random pairs by eye:
+
+- Does the target image look like a plausible result of applying the prompt to the control image(s)?
+- Is it clear what changed between control and target, and does the prompt describe that change?
+- Is the subject/scene the same in control and target (they are before/after, not unrelated images)?
+
+If any pair fails this check, the data has a consistency problem that will reduce LoRA quality.
+Finding and fixing a few bad pairs early is much cheaper than diagnosing a poorly-trained model later.
+
+### 3.8 Hold out a test set
+
+Before finalising your dataset, **set aside at least 3 samples that will not
+be used for training**. These become your held-out test set for §9.2
+post-training visual comparison (base model vs. trained LoRA).
+
+Choosing which samples to hold out:
+- Pick samples that are **representative** of the edit you are teaching —
+  the comparison is only meaningful if the test images resemble the training
+  distribution.
+- Do **not** reuse training samples as test samples. The model has seen those
+  images during training, so any apparent quality difference is unreliable.
+
+**For HuggingFace / parquet datasets**: the test split parquet
+(`<dataset_dir>/data/test-*.parquet`) is usually provided automatically.
+Use it directly in §9.2; no extra step needed here.
+
+**For local directory datasets**: physically move the held-out pairs to a
+separate folder (e.g. `test/`) before running `dataset_validate.py`. Point
+`--test-parquet` in §9.2 at this folder (or adapt `inference_compare.py`
+to load local images directly).
+
+If you are working from a small dataset where holding out samples would
+leave too few for training (see §3.3 thresholds), collect a few additional
+pairs specifically for testing rather than reducing the training set.
+
+## 4. Environment Setup
+
+§2 covered the system-level prerequisites (oneAPI, driver, conda). §4
+sets up the Python training environment. **One-time per machine**; reuse
+across runs.
+
+### 4.1 Create the conda env
+
+```bat
+conda create -n qwen-image-edit-xpu python=3.12 -y
+conda activate qwen-image-edit-xpu
+```
+
+(If a torch+xpu base env already exists locally, prefer cloning it —
+`conda create -n qwen-image-edit-xpu --clone <existing-xpu-env>` — to avoid
+re-downloading the torch wheel.)
+
+### 4.2 Install torch+xpu
+
+**Recommended: latest wheel (let pip pick the version)**
+
+```bat
+pip install torch torchvision --index-url https://download.pytorch.org/whl/xpu
+```
+
+Minimum supported: `torch >= 2.9.0+xpu`. Confirm the installed version
+matches your oneAPI version (§2.7 version table). For example,
+`torch 2.11.0+xpu` requires oneAPI 2025.3.
+
+**Pin a specific version** (if your oneAPI is already installed and you want
+to match it, rather than upgrade oneAPI):
+
+```bat
+pip install torch==2.11.0 torchvision --index-url https://download.pytorch.org/whl/xpu
+```
+
+`torchvision` follows `torch` automatically from the same XPU channel — no
+need to pin it separately.
+
+### 4.3 Install project dependencies
+
+Before running `pip install`, the upstream `requirements.txt` needs two
+edits (a fresh clone of `tsiendragon/qwen-image-finetune` ships with both
+problems):
+
+**1. Comment out `transformer_engine[pytorch]`** — CUDA-only, no XPU equivalent.
+Installing it will fail on a machine without NVCC:
+
+```diff
+# requirements.txt
+- transformer_engine[pytorch]
++ # XPU: transformer_engine is CUDA-only — comment out
++ # transformer_engine[pytorch]
+```
+
+**2. Pin `bitsandbytes>=0.48.2`** — the unversioned `bitsandbytes` line may
+resolve to an older build that lacks the XPU backend:
+
+```diff
+- bitsandbytes
++ bitsandbytes>=0.48.2
+```
+
+Then install:
+
+```bat
+pip install -r requirements.txt
+```
+
+If §6 adaptation has already been applied (the repo has `device_utils.py`
+and the XPU patches in place), this is the only required pre-install edit.
+
+### 4.4 Activate oneAPI in the current shell
+
+The training launcher (`templates/launchers/train_xpu.bat`) handles this
+automatically; for ad-hoc verification:
+
+```bat
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+```
+
+If this reports `'vars.bat' is not recognized` errors, see §10.1: clear
+`NoDefaultCurrentDirectoryInExePath` across the call. The launcher template
+does this; for a manual session, run from a CMD opened directly (not from
+inside another wrapper shell).
+
+### 4.5 Verify
+
+```bat
+python templates\probe_hw.py
+```
+
+PASS criteria — JSON output must show:
+- `xpu_available: true`
+- `torch_version` ending in `+xpu`
+- `bnb_version` >= `0.48.2`
+- `bnb_xpu_available: true`
+- `oneapi_version` non-null (only if §4.4 setvars activated; expected null
+  for fresh sessions before launcher runs)
+
+If any of the first four fail, do NOT proceed to §6 — fix the environment first.
+
+## 5. Hardware Probe → Config Recommendation
+
+Two scripts produce a training YAML matched to the user's machine:
+
+```bash
+python templates/probe_hw.py > probe.json
+python templates/recommend_config.py --probe probe.json --out config.yaml
+```
+
+`probe_hw.py` emits hardware/software JSON (schema in its own header).
+`recommend_config.py` reads that JSON, applies the rules table below,
+and emits a complete training YAML.
+
+The YAML output contains TODO placeholders for machine-specific paths the
+user (or agent) must fill in:
+- `model.pretrained_model_name_or_path` (original Qwen-Image-Edit model directory)
+- `model.transformer_path` (pre-quantized NF4 dir from §7.1 — optional; omit to use online NF4 quantization)
+- `data.init_args.dataset_path` (validated dataset; see §3)
+- `logging.output_dir` and `cache.cache_dir`
+
+Pass `--dataset-path <path>` to the recommender to fill the dataset_path
+placeholder inline.
+
+The recommender also prints a list of selected §7 catalog patterns to stderr
+— these are the conditional optimizations from §7 that apply to this machine.
+
+### 5.1 Recommended settings
+
+> **Minimum required: 32 GB AI PC.** 16 GB is not supported: the NF4 DiT
+> alone requires ~10 GB XPU allocation, leaving insufficient headroom for
+> training activations on a 16 GB unified-memory machine. The minimum
+> practical tier is **32 GB**.
+
+The recommender emits the following settings. Each row includes the reason
+and test evidence where available.
+
+| Setting | Value | Why |
+|---|---|---|
+| `model.quantize_type` | `nf4` | Scope of this skill; NF4 QLoRA only |
+| `model.transformer_path` | `<pre-quant dir or null>` | **Optional.** Online NF4 uses shard-by-shard streaming so memory impact is negligible. Value of pre-quantizing is startup time (saves one quantization pass per run). Recommended for multiple training iterations. See §7.1. |
+| Pre-quantize text_encoder (`model.text_encoder_path`) | optional; see §7.2 | Reduces text_encoder from ~15 GB to ~5.5 GB (NF4). Reduces cache-phase RAM by ~8 GB on 32 GB machines — eliminates heavy paging. See §7.2 for measured effect and prep steps. |
+| `cache.use_cache` (§7.4) | `true` | **Required.** Without caching, the trainer keeps text_encoder active during fit to encode prompts per batch while the NF4 DiT is also loaded — combined memory pressure crashes on 32 GB machines. Cache-first runs text_encoder and VAE at cache time, writes pre-computed embeddings and image latents to disk, then frees text_encoder before the NF4 DiT loads for fit. |
+| Mode-aware loading (§7.3) | always | Enforces the above separation at the code level |
+| `data.processor.target_size` | `[384, 672]` default | Balanced default; three-tier options: |
+| ↳ `[256, 448]` | Lower XPU demand | Significantly faster per step; fast iteration and prototyping |
+| ↳ `[384, 672]` | **Default** | Balanced default |
+| ↳ `[512, 768]` | Higher (tight on 32 GB) | Significantly slower; system RAM reaches the 32 GB ceiling on 32 GB machines |
+| `train.gradient_checkpointing` | `true` | **Recommended at all resolutions; required at ≥[384,672].** Without it, activation memory causes XPU out-of-memory during attention at the default and larger resolutions. Reducing LoRA rank does not resolve this. |
+| `train.max_train_steps` | `1000` | Practical starting point for a narrow task on a ~35-sample dataset. Reduce to **50–200** for a quick pipeline sanity check; increase for larger datasets or more complex edits. Monitor smooth loss — stop when it plateaus across consecutive checkpoints. |
+| `train.gradient_accumulation_steps` | `2` | Effective batch-size > 1 without extra per-step memory |
+| `optimizer.class_path` | `bitsandbytes.optim.Adam8bit` | Memory difference vs `torch.optim.Adam` is negligible at this LoRA scale. Real value: measurably faster per step via Triton-backed optimizer. |
+| `lora.dtype` | `"bf16"` | Optional; stores LoRA adapter weights in bf16 vs fp32 default (~48 MB savings at r=16 — negligible). §6.6 NF4-A2 autocast handles forward compute dtype; this is a complementary parameter-storage setting. |
+| `lora.r` | `16` | Memory-neutral — activation memory dominates, not LoRA parameters. Quality choice; adjust freely between 8–32. |
+| `data.batch_size` | `1` | Single GPU, minimum |
+| `data.num_workers` | `1` | Windows spawn-mode; qflux pydantic schema rejects 0 |
+| `train.mixed_precision` | `"no"` | accelerate's bf16 path wraps `torch.autocast("cuda")` — does not dispatch to XPU. qflux wraps the NF4 forward pass in `torch.autocast("xpu", ...)` internally (see §6). |
+
+### 5.2 Manual override
+
+If the probe is incorrect (e.g. `oneapi_version = null` because `setvars.bat`
+hasn't run yet — see §4) or different settings are desired:
+1. Edit the generated YAML directly. §5.1 documents what each
+   key does and when to set it.
+2. Or hand-edit `probe.json` before piping into the recommender.
+
+The recommender is **conservative** — it picks the safest config that fits.
+Loosen settings (larger batch, larger LoRA rank, lower grad-accum) only after
+the conservative config trains successfully and you verify XPU memory has
+headroom (via `templates/monitor_xpu_memory.py`).
+
+> **HuggingFace / parquet dataset path**: `--dataset-path` expects a **local
+> directory** with `training_images/` and `control_images/` subdirectories
+> (see §3.2). If your dataset is in HuggingFace parquet format (downloaded
+> via HF Hub), the recommender will emit a plain string path that the qflux
+> loader cannot parse. Edit the generated YAML's `data.init_args.dataset_path`
+> to use the dict format before training:
+>
+> ```yaml
+> data:
+>   init_args:
+>     dataset_path:
+>       - repo_id: <path/to/local-parquet-dir>
+>         split: train
+> ```
+
+
+## 6. Framework Adaptation
+
+> **Scope**: §6 describes adapting the **original `tsiendragon/qwen-image-finetune`
+> repository** (CUDA-only, unmodified). If you cloned an already-adapted fork,
+> some or all of these changes may already be present — run the §6.6 import
+> test to confirm before re-applying anything.
+
+The `qflux` codebase (qwen-image-finetune's package) hardcodes `torch.cuda.*`
+calls — it's a custom training loop, not built on HF Trainer's auto-XPU
+detection. The adaptations below are required before training will run on XPU.
+
+### 6.1 Device-agnostic helpers (`device_utils.py`)
+
+Replace each `torch.cuda.*` call in the framework with a device-agnostic
+wrapper that checks XPU first. This confines the XPU adaptation to the
+framework's own source files and leaves third-party libraries (Triton,
+bitsandbytes, accelerate) untouched.
+
+In qwen-image-finetune the wrappers live at `src/qflux/utils/device_utils.py`.
+Verify the following helpers are present; if adapting a fresh clone, create
+this file before any other change.
+
+```python
+# src/qflux/utils/device_utils.py
+# enable XPU: device-agnostic helpers — call these instead of torch.cuda.* directly.
+import contextlib
+import torch
+
+def device_empty_cache() -> None:
+    if torch.xpu.is_available():           # enable XPU
+        torch.xpu.empty_cache()
+    elif torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+def device_synchronize() -> None:
+    if torch.xpu.is_available():           # enable XPU
+        torch.xpu.synchronize()
+    elif torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+def device_manual_seed_all(seed: int) -> None:
+    if torch.xpu.is_available():           # enable XPU
+        torch.xpu.manual_seed_all(seed)
+    else:
+        torch.cuda.manual_seed_all(seed)
+
+def device_context(device):
+    """Device context manager replacing torch.cuda.device().
+
+    torch.xpu.device("cpu") raises; this helper returns nullcontext() for
+    CPU and the correct accelerator context otherwise.
+    """
+    device_str = str(device) if device is not None else "cpu"
+    if device_str == "cpu":
+        return contextlib.nullcontext()
+    if torch.xpu.is_available():           # enable XPU
+        return torch.xpu.device(device)
+    return torch.cuda.device(device)
+```
+
+Replace each direct `torch.cuda.*` call in the framework:
+
+| Original | Replacement | Import |
+|---|---|---|
+| `torch.cuda.empty_cache()` | `device_empty_cache()` | `from qflux.utils.device_utils import device_empty_cache` |
+| `torch.cuda.synchronize()` | `device_synchronize()` | `from qflux.utils.device_utils import device_synchronize` |
+| `torch.cuda.manual_seed_all(s)` | `device_manual_seed_all(s)` | `from qflux.utils.device_utils import device_manual_seed_all` |
+| `with torch.cuda.device(dev):` | `with device_context(dev):` | `from qflux.utils.device_utils import device_context` |
+
+### 6.2 Find and fix residual patterns
+
+The `device_utils.py` helpers cover functional calls. A separate scan is
+needed for string-based device comparisons and CUDA-only library imports,
+which helpers cannot address:
+
+```bash
+grep -rn "torch\.cuda\.\|flash_attention_2\|transformer_engine\|device\.type.*cuda" src/qflux/
+```
+
+| Pattern | Fix |
+|---|---|
+| `flash_attention_2` (in `from_pretrained` calls or `config.json`) | Replace with `"sdpa"`. Flash Attention 2 is CUDA-only |
+| `transformer_engine` import / use | Comment out — CUDA-only library |
+| `device.type == "cuda"` literal compare | Add an `xpu` branch (string compare can't be patched) |
+| `mp.set_start_method("spawn", force=True)` | Guard with `if not torch.xpu.is_available(): ...`. Windows defaults to `spawn` already; `force=True` raises `RuntimeError: context has already been set` |
+| `torch.cuda.device(device)` context manager | Replace with `device_context(device)` from `device_utils.py`. `torch.xpu.device("cpu")` raises when `device="cpu"` (e.g. text_encoder placed on CPU for inference); `device_context()` returns `nullcontext()` for CPU, the correct accelerator context otherwise |
+| `train_epoch()` ignores `max_train_steps` — runs `num_epochs × dataset_size` steps instead | Add a guard at the top of the per-batch loop in `train_epoch()`: `if self.global_step >= self.config.train.max_train_steps: return` |
+
+Example `device.type` fix in a config validator:
+
+```python
+if d.type == "cuda":
+    if not torch.cuda.is_available():
+        raise ValueError(f"CUDA not available but got device={d}.")
+# enable XPU: validate XPU device availability
+if d.type == "xpu" and not torch.xpu.is_available():
+    raise ValueError(f"XPU not available but got device={d}.")
+```
+
+### 6.3 accelerate single-card XPU config
+
+`qflux.main` launches via `accelerate launch --config_file <path>`. Ship an
+XPU-specific config alongside the CUDA one (e.g., `accelerate_config_xpu.yaml`):
+
+```yaml
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: NO
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 1
+main_training_function: main
+dynamo_backend: 'no'
+use_cpu: false
+deepspeed_config: {}
+```
+
+Key differences from a typical CUDA multi-GPU config:
+
+| Field | CUDA multi-GPU | XPU single-card | Why |
+|---|---|---|---|
+| `distributed_type` | `MULTI_GPU` | `NO` | Single process; no collective ops |
+| `mixed_precision` | `bf16` | `'no'` | accelerate's bf16 wraps `torch.autocast("cuda", ...)` — does not dispatch to XPU. Apply `torch.autocast("xpu", ...)` in the trainer instead (§6.6 NF4-A2) |
+| `dynamo_backend` | `inductor` | `'no'` | XPU `torch.compile` is experimental; accelerate's wrapper often fails through it |
+
+> **YAML gotcha**: `dynamo_backend: no` unquoted parses as YAML boolean
+> `False`; accelerate then calls `.upper()` on it and raises
+> `AttributeError: 'bool' object has no attribute 'upper'`. Always quote
+> `'no'` (and same for `mixed_precision: 'no'`).
+
+### 6.4 Pydantic schema relaxation for `num_workers`
+
+Many CUDA-origin frameworks (qflux included) declare `num_workers` with a
+`> 0` constraint. On Windows under `spawn` start-method, classes registered
+via `trust_remote_code` are not picklable across processes — workers crash
+on dataset iteration. Setting `num_workers = 0` would fix it but the schema
+rejects 0.
+
+Relax the constraint to `>= 0` in the dataset config validator. The
+recommender (§5) defaults to `1` (since 0 disables multiprocessing entirely
+and slows data loading), but `0` should at least be acceptable as an escape
+hatch for the picklability case.
+
+### 6.5 BitsAndBytes XPU backend (informational)
+
+Knowing which bnb operations dispatch to which backend on XPU helps the
+agent diagnose failures and explains why §2 requires Visual Studio + oneAPI.
+For `bitsandbytes >= 0.48.2`:
+
+| Operation | Backend | When it runs |
+|---|---|---|
+| `dequantize_4bit` | **SYCL** | Every NF4 forward and backward pass |
+| `dequantize_blockwise` | **SYCL** | Used alongside NF4 dequant |
+| `gemv_4bit` | **SYCL** | Inference-only single-token path |
+| `quantize_4bit`, `quantize_blockwise` | **Triton** | Initial quantization (e.g. §7.1 pre-quantize step) |
+| `optimizer_update_8bit_blockwise`, `optimizer_update_32bit` | **Triton** | Every `bnb.optim.Adam8bit.step()` call |
+
+**Key consequence**: NF4 forward/backward does not use a dedicated NF4
+gemm kernel — bnb dequantizes the 4-bit weight via SYCL and hands off to
+PyTorch's native XPU matmul. Only the **optimizer step** and
+**initial quantization** actually go through Triton.
+
+**Practical impact**: if a training run loads a pre-quantized NF4
+checkpoint (§7.1 output) and uses `Adam8bit`, Triton kernel JIT compile
+runs on the first optimizer step — this is why §2.7 oneAPI + §2.6 Visual
+Studio C++ workload are required.
+
+The dispatch above is empirical for `bitsandbytes 0.49.2`. Newer versions
+may shift; if odd failures appear, check `bitsandbytes/backends/xpu/ops.py`
+in your installed bnb version for the current registration.
+
+### 6.6 NF4 QLoRA required patches
+
+When adapting the framework for NF4 QLoRA, two additional patches are
+required beyond the general XPU adaptation in §6.1-§6.4. In
+qwen-image-finetune these are already applied; verify they are present
+after applying §6.
+
+#### NF4-A1. `torch_dtype` on `from_pretrained`
+
+**Symptom if missing**: `RuntimeError` from attention op with a dtype
+mismatch between fp16/bf16/fp32 tensors on the first forward pass.
+
+**Why**: without `torch_dtype`, non-quantized params (norms, biases) stay at
+the checkpoint's stored dtype. PEFT LoRA adapters default to fp32. The
+cross-dtype attention kernel rejects mixed inputs.
+
+**Fix**: pass `torch_dtype` to the NF4 `from_pretrained` call:
+```python
+transformer = QwenImageTransformer2DModel.from_pretrained(
+    pretrained_model_name_or_path, subfolder="transformer",
+    quantization_config=bnb_config,
+    torch_dtype=weight_dtype,   # aligns non-quantized params to training dtype
+    attn_implementation="sdpa",
+)
+```
+
+In qwen-image-finetune: `src/qflux/models/load_model.py` — search for
+`torch_dtype=weight_dtype` in the `load_transformer` function.
+
+#### NF4-A2. `torch.autocast` wrap for LoRA forward pass
+
+**Symptom if missing**: dtype mismatch persists after NF4-A1. PEFT LoRA
+adapters remain fp32 by default; in DiT joint attention their fp32 outputs
+collide with bf16 outputs from other branches.
+
+**Why**: `bf16_input @ fp32_lora_weight` promotes to fp32. The mismatch
+only surfaces after NF4-A1 resolves the norm dtype issue.
+
+**Fix**: wrap the trainable model's forward in `torch.autocast`:
+```python
+_autocast_device = "xpu" if torch.xpu.is_available() else "cuda"
+with torch.autocast(_autocast_device, dtype=weight_dtype):
+    output = model(inputs, ...)
+```
+
+This coerces all ops to `weight_dtype` without changing effective training
+precision. Also eliminates the need to set `lora.dtype: bf16` for memory
+savings — autocast handles the computation dtype at runtime.
+
+In qwen-image-finetune: `src/qflux/trainer/qwen_image_edit_trainer.py` —
+search for `torch.autocast(_autocast_device, dtype=self.weight_dtype)`.
+
+### 6.7 Verify the adaptation before training
+
+Write a throwaway import-test that loads each module you touched:
+
+```python
+# _test_residual_cuda.py — delete after use
+import os, sys
+sys.path.insert(0, "src")
+os.environ["QFLUX_DOTENV_LOADED"] = "1"  # skip HF login on package import
+import torch
+
+# Add one line per modified module — examples:
+from qflux.utils.device_utils import device_empty_cache  # noqa: F401
+from qflux.trainer.qwen_image_edit_trainer import QwenImageEditTrainer  # noqa: F401
+print("[OK] all modified modules imported cleanly")
+
+# If you touched attn_implementation logic, also assert:
+# from qflux.models.load_model import _attn_implementation
+# assert _attn_implementation() == "sdpa"
+```
+
+A clean run = no syntax errors and no broken references introduced by your
+changes. End-to-end smoke is in §11.
+
+## 7. Memory Optimization Catalog
+
+> Each subsection 7.x starts with a **Trigger condition** — machine-judgable
+> from §5 probe JSON / recommender output. Apply ONLY the subset §5 selected.
+> Patterns are independent unless explicitly noted.
+
+### 7.1 Pre-quantize transformer (NF4)
+
+**Trigger condition**: optional; recommended when running training more than
+once. A single exploratory run can skip this step (use online NF4 instead).
+
+This skill always uses NF4 for the transformer — the question is *how* NF4
+weights are loaded at each training start:
+
+| | Pre-quantized (`transformer_path` set) | Online NF4 (`transformer_path` null) |
+|---|---|---|
+| Disk space | +~10 GB for the NF4 checkpoint dir | No extra |
+| Per-run startup | Fast — load ~10 GB NF4 directly | Slower — stream bf16 shards from the original repo and quantize on the fly; Triton `quantize_4bit` kernel JIT-compiles on first use |
+| Training-time memory | Essentially the same as online NF4 | Essentially the same as pre-quantized |
+| Original model needed on disk | Still required for text_encoder, VAE, scheduler | Still required |
+
+The bf16 transformer checkpoint on disk is ~38 GB; the NF4 output is ~10 GB
+(~4× smaller). During online quantization the model is loaded shard-by-shard
+so the peak RAM is much less than 38 GB, but the process still takes
+meaningful time on every run start.
+
+**One-time prep** — output is reused indefinitely:
+
+```bat
+templates\launchers\quantize_xpu.bat <SRC> <DST>
+```
+
+or manually (after activating conda + setvars.bat):
+
+```bat
+python templates\quantize_transformer_nf4.py --src <SRC> --dst <DST>
+```
+
+**After quantizing**, set `model.transformer_path` in your training config:
+
+```yaml
+model:
+  pretrained_model_name_or_path: <SRC>   # still needed for text_encoder, VAE, etc.
+  transformer_path: <DST>                # NF4-quantized DiT
+  quantize_type: "nf4"
+```
+
+The qflux model loader reads `quantization_config` from `<DST>/config.json`
+and skips online quantization automatically.
+
+### 7.2 Pre-quantize text_encoder (NF4)
+
+**Trigger condition** (machine-judgable):
+- `ram_gb <= 32` → recommended. At 32 GB, the cache phase loads the ~15 GB
+  bf16 text_encoder simultaneously with the dataset and VAE, pushing system
+  RAM close to its physical limit and triggering virtual memory paging —
+  slowing cache significantly.
+- `32 < ram_gb <= 64` → optional (extra headroom).
+- `ram_gb > 64` → not needed.
+
+The Qwen2.5-VL text_encoder weighs ~15 GB at bf16 (15.4 GiB as shown in
+Windows Explorer). Pre-quantizing to NF4 drops it to ~5.5 GB on disk.
+
+**One-time prep** (run once per machine):
+
+```bat
+templates\launchers\quantize_text_encoder_xpu.bat <SRC> <DST>
+```
+
+or manually (after activating conda + setvars.bat):
+
+```bat
+python templates\quantize_text_encoder_nf4.py ^
+    --src <path\to\Qwen-Image-Edit-pipeline> ^
+    --dst <path\to\Qwen-Image-Edit-nf4-text-encoder>
+```
+
+**Add to config**:
+
+```yaml
+model:
+  text_encoder_path: "<path\to\Qwen-Image-Edit-nf4-text-encoder>"
+```
+
+The qflux loader auto-detects `quantization_config` in the saved `config.json`
+and skips online quantization on subsequent runs — identical to the
+`transformer_path` pattern in §7.1.
+
+**Measured effect** (32 GB AI PC, validated):
+
+| Phase | bf16 text_encoder | NF4 text_encoder |
+|---|---|---|
+| Cache phase RAM | near physical limit — may trigger virtual memory paging | well within limit — no paging |
+| Disk size | ~15 GB | ~5.5 GB |
+| Cache throughput | may slow significantly if paging occurs | normal |
+| Fit phase RAM | unchanged | unchanged — fit does not load text_encoder |
+
+**Note on cache compatibility**: NF4 embeddings differ slightly from bf16.
+If you have an existing cache built with bf16 text_encoder, rebuild it after
+switching to `text_encoder_path`.
+
+### 7.3 Mode-aware loading
+
+**Trigger condition** (machine-judgable):
+- Cache phase (`--cache`): always apply `skip_dit` — DiT is not invoked during
+  embedding pre-compute, regardless of machine.
+- Fit phase: apply `skip_text_encoder` when `cache.use_cache == true`, cache
+  files exist on disk, AND `validation.enabled == false`. Recommended for all
+  AI PC tiers; effectively mandatory at 32 GB and below.
+
+The trainer (`qflux.trainer.qwen_image_edit_trainer`) loads only the components used
+in the current run mode. Two skip-paths reclaim memory peaks that would otherwise
+force quantization or smaller batches.
+
+| Phase / mode | Skipped component | Measured savings | Why it's safe |
+|---|---|---|---|
+| `--cache` (TrMode.cache) | DiT (transformer, ~10 GB) | **REQUIRED** — loading DiT alongside text_encoder (~15 GB) during cache phase exceeds CPU RAM on 32 GB AI PC and crashes. Cache phase only invokes text_encoder + VAE; DiT is not needed. | Cache phase only forwards through text_encoder + VAE; DiT is never invoked |
+| `fit` + `cache.use_cache=true` + cache populated + validation disabled | text_encoder (Qwen2.5-VL bf16, ~15 GB) | **REQUIRED** — loading text_encoder alongside DiT during fit phase exceeds CPU RAM on 32 GB AI PC and crashes. With mode-aware load, CPU RAM stays within budget. | All training samples have pre-computed embeddings; text_encoder is only needed for live encoding (e.g., validation samples) |
+
+VAE is **always** loaded and is not subject to any skip logic. Unlike
+text_encoder (~15 GB), VAE is only ~250 MB — unloading it saves negligible
+memory. Additionally, its config attributes (`scale_factor`, `latent_mean`,
+`latent_std`, `z_dim`) are used throughout the trainer's forward pass
+regardless of mode, so it must remain resident.
+
+Implementation pattern (in
+`src/qflux/trainer/qwen_image_edit_trainer.py`'s `load_model` after
+applying §6 framework adaptation):
+
+```python
+from qflux.data.config import TrMode
+
+is_cache_mode = self.config.mode == TrMode.cache
+cache_will_serve_all = (
+    self.config.mode == TrMode.fit
+    and self.use_cache
+    and self.cache_exist
+    and not self.config.validation.enabled
+)
+skip_dit = is_cache_mode
+skip_text_encoder = cache_will_serve_all
+```
+
+Required config flags to enable the fit-skip path:
+
+```yaml
+cache:
+  use_cache: true        # see §7.4 cache-first workflow
+  cache_dir: <path>      # cache must exist before fit starts
+validation:
+  enabled: false         # or run validation in a separate pass after fit
+```
+
+If you need validation during fit (periodic sample generation), the
+text_encoder MUST stay loaded — the ~15 GB cost is unavoidable. On 32 GB
+machines this typically forces NF4 text_encoder (§7.2) instead of skipping.
+
+### 7.4 Cache-first workflow
+
+**Trigger condition** (machine-judgable): apply when `cache.use_cache=true`, which the
+§5 recommender sets whenever `text_encoder` size ≥ trainable model size. For
+qwen-image-edit specifically: text_encoder (Qwen2.5-VL bf16, ~15 GB) dwarfs the
+trainable LoRA path on the DiT (~50 MB), so cache mode is recommended on every
+AI PC tier. Skip only if the user explicitly disables caching.
+
+For qwen-image-edit, the text_encoder (Qwen2.5-VL) and VAE produce conditioning
+signals without themselves being trained. Pre-compute their outputs once and reload
+from disk each step — this frees encoder memory entirely during the training loop,
+leaving only the ~10 GB DiT (NF4) + LoRA + Adam8bit state on XPU during fit.
+
+Two-phase flow:
+
+```
+[cache step]  python -m qflux.main --config <cfg> --cache
+              ├─ load text_encoder + VAE onto XPU (DiT skipped — see §7.3)
+              ├─ encode all training samples → save embeddings to cache_dir
+              └─ encoders freed after pass; build time scales with dataset size
+
+[fit step]    accelerate launch ... -m qflux.main --config <cfg>
+              ├─ cache detected → skip loading text_encoder (see §7.3)
+              ├─ only DiT (NF4) + LoRA + optimizer resident on XPU
+              └─ each step: load pre-computed embeddings from disk
+```
+
+Config block:
+
+```yaml
+cache:
+  devices:
+    text_encoder: xpu:0
+    vae: xpu:0
+  cache_dir: "outputs/<run_name>/cache"
+  use_cache: true
+```
+
+Reuse semantics: the cache is built once per dataset and reused across training runs
+(LoRA rank sweeps, learning-rate sweeps, etc., all hit the same cache dir). Only
+rebuild when the dataset itself changes.
+
+Pairs naturally with §7.3 (mode-aware loading), which is what actually skips
+the encoder loads during fit.
+
+
+
+## 8. Training Execution
+
+By the time the agent reaches §8: env is set up (§2, §4), framework is
+adapted (§6), dataset is validated (§3), and `recommend_config.py` has
+emitted a YAML config plus a list of selected §7 patterns to apply. §8
+runs the actual training.
+
+### 8.1 Apply selected §7 patterns
+
+The §5 recommender printed a list of patterns to stderr. Apply each before
+launching:
+
+| Pattern | What "applying" means |
+|---|---|
+| §7.1 Pre-quantize transformer | **Optional.** Run `templates/quantize_transformer_nf4.py` once; set `model.transformer_path` in the config. Skip to use online NF4 (slower startup, same training memory). |
+| §7.2 Pre-quantize text_encoder | **For 32 GB machines**: run `templates\launchers\quantize_text_encoder_xpu.bat` once; set `model.text_encoder_path` in config. Reduces cache-phase RAM by ~8 GB. See §7.2. |
+| §7.3 Mode-aware loading | Already implemented in qflux trainer (after §6 adaptation); verify `cache.use_cache: true` in the config and `validation.enabled: false` for fit. |
+| §6.6 NF4 QLoRA patches | NF4-A1 (torch_dtype) + NF4-A2 (autocast) baked into qflux after §6 adaptation. Verify with §6.7 import test. |
+| §7.4 Cache-first workflow | Run cache phase before fit — see §8.2. |
+| §5.1 all other settings | Already in recommender output YAML; no separate action needed. |
+
+### 8.2 Cache phase (one-time per dataset)
+
+```bat
+templates\launchers\train_xpu.bat <config.yaml> --cache
+```
+
+Runs the text_encoder and VAE forward over every training sample and writes
+embeddings to `cache.cache_dir`. Build time scales linearly with sample count
+and image resolution; a dataset of ~30-50 samples at default [384, 672]
+resolution completes in one pass.
+
+PASS: process exits 0; `cache.cache_dir` contains a per-sample directory
+structure (one folder per sample with embedding tensors). Re-running with
+the same dataset + config is a no-op (cache is hash-keyed).
+
+> **Corrupt cache (interrupted run)**: If a previous cache run was interrupted,
+> it may leave empty or partial files. Re-running will fail with
+> `json.JSONDecodeError` or `KeyError` on the first sample. Fix: delete the
+> entire `cache.cache_dir` directory and re-run the cache phase from scratch.
+
+### 8.3 Fit phase
+
+```bat
+templates\launchers\train_xpu.bat <config.yaml>
+```
+
+Launches `accelerate launch --config_file accelerate_config_xpu.yaml -m qflux.main ...`.
+Logs go to stdout; checkpoints land in
+`<logging.output_dir>/checkpoint-<epoch>-<step>/`.
+
+PASS criteria for a healthy run:
+- **Step 1 completes without exception**
+- **`torch.xpu.memory_allocated() > 0` during the step** — sample from a
+  second CMD:
+  ```bat
+  python -c "import torch; print(torch.xpu.memory_allocated()/1e9, 'GB')"
+  ```
+  A near-zero value means compute is happening on CPU (typically §10 (troubleshooting)
+  not applied).
+- **Loss is finite and shows a downward trend after the warmup period**
+  (batch-level fluctuation is normal; the warming period is set by
+  `train.warmup_steps` in the config).
+
+### 8.4 Resume from checkpoint
+
+If interrupted, set `resume: <checkpoint-path>` in the config and re-launch.
+qflux's checkpoint loader handles state restoration.
+
+### 8.5 Monitoring across longer runs
+
+The training log emits per-step `xpu memory: N.NN GB` lines (decimal GB,
+matching Python memory tools; approximately 7% higher than the GiB values
+Windows Explorer displays — both describe the same memory). Memory should
+be stable across steps; linear growth indicates a tensor or gradient leak.
+
+If step time degrades mid-run, check the Triton kernel cache (§10.4) —
+stale kernels after a oneAPI / torch upgrade can manifest as erratic
+slowdowns.
+
+## 9. Validation
+
+Validation answers the question: **did the LoRA learn the intended edit?**
+The approach has three layers of increasing depth — use as many as needed.
+
+### 9.1 In-training visual monitoring (TensorBoard sampling)
+
+The framework can generate sample outputs during training at regular
+intervals and log them to TensorBoard, giving a visual sense of progress
+without writing any extra code.
+*(Source: `docs/guide/validation_sampling.md`, qwen-image-finetune v3.1.0)*
+
+**Configure in the training YAML:**
+
+```yaml
+validation:
+  enabled: true
+  steps: 100          # generate samples every 100 training steps
+  max_samples: 2      # 2-5 is practical; more = slower validation pass
+  seed: 42            # fixed seed for consistent comparison across checkpoints
+  dataset:
+    class_path: "qflux.data.dataset.ImageDataset"
+    init_args:
+      dataset_path:
+        - split: test
+          repo_id: <your-dataset>
+      selected_control_indexes: [1]
+      processor:
+        class_path: "qflux.data.preprocess.ImageProcessor"
+        init_args:
+          process_type: center_crop
+          target_size: [384, 672]
+          controls_size: [[384, 672], [512, 512]]
+```
+
+**Start TensorBoard** (in a separate terminal):
+```bash
+tensorboard --logdir=outputs/<run_name>/logs
+```
+Then open the **Images** tab to compare outputs across checkpoints.
+
+> ⚠️ **32 GB AI PC constraint**: `validation.enabled: true` disables the
+> §7.3 mode-aware loading optimization, forcing `text_encoder` to stay in
+> memory during fit. On 32 GB machines this causes OOM (see §7.3). Options:
+> - **Recommended**: keep `validation.enabled: false` during training; run §9.2 post-training instead.
+> - Train on a 64 GB+ machine where the extra ~15 GB fits.
+> - §7.2 NF4 text_encoder reduces text_encoder from ~15 GB to ~5.5 GB, which may make in-training validation feasible on 32 GB — not tested with `validation.enabled: true`.
+
+### 9.2 Post-training visual comparison (inference_compare.py)
+
+After training completes, run inference twice on a held-out test set — once
+with the base model and once with the trained LoRA — then compare the outputs.
+
+**Getting a test split**
+
+If your dataset is a HuggingFace dataset (downloaded locally), the test split
+parquet is typically at `<dataset_dir>/data/test-*.parquet`. If your dataset
+is a local directory, hold out 3–5 sample pairs before training and use those.
+Point `--test-parquet` at the parquet file, or adapt `inference_compare.py`
+to load local images directly if you have no parquet.
+
+**Running** (from the qwen-image-finetune project root, with conda env active):
+
+```bat
+REM Activate environment first (same as training)
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+call conda activate qwen-image-edit-xpu
+set QFLUX_DOTENV_LOADED=1
+set PYTHONUTF8=1
+
+REM Step 1 — base model (no LoRA)
+python templates\inference_compare.py ^
+    --config <config.yaml> ^
+    --test-parquet <path\to\test.parquet> ^
+    --output-dir outputs\compare\<run>\base ^
+    --num-samples 5
+
+REM Step 2 — LoRA-applied
+python templates\inference_compare.py ^
+    --config <config.yaml> ^
+    --test-parquet <path\to\test.parquet> ^
+    --output-dir outputs\compare\<run>\lora ^
+    --num-samples 5 ^
+    --lora-weight outputs\<run>\checkpoint-<step>\pytorch_lora_weights.safetensors
+```
+
+Each output directory contains `sample_NN_<id>.png` (model output),
+`sample_NN_<id>__target.png` (ground-truth if available),
+and `manifest.json` with prompts and metadata.
+
+**Quality and speed trade-offs**
+
+Two parameters worth tuning to improve output quality, independently of the
+LoRA weights themselves:
+
+- **Model precision**: higher-precision DiT and text encoder consistently
+  produce better results. Three configurations, ordered by quality:
+
+  | Config | DiT | Text encoder | Required system RAM |
+  |---|---|---|---|
+  | A | NF4 on XPU | NF4 on XPU | 32 GB + XPU cap (§2.3) |
+  | B *(default)* | NF4 on XPU | bf16 on CPU | 32 GB |
+  | C | bf16 on XPU | bf16 on CPU | ≥64 GB |
+
+  `inference_compare.py` uses config B by default. To use config A, set
+  `model.text_encoder_path` in your config (§7.2) so both models run on XPU.
+
+- **Inference steps** (`--num-inference-steps`, default 20): more steps improve
+  quality at the cost of time. Start with the default and increase only if the
+  output quality is insufficient.
+
+> **32 GB AI PC — constraints by config**:
+> - **Config B** (default): system RAM approaches 31–32 GB. On some 32 GB
+>   machines, bf16 text_encoder (~15 GB) may cause OOM when loading alongside
+>   NF4 DiT. If this happens, fall back to Config A by setting
+>   `model.text_encoder_path` (§7.2) — this trades some output quality for
+>   reliability.
+> - **Config A** (both models on XPU): XPU demand is ~20 GB at [384,672]
+>   resolution. If you see `UR_RESULT_ERROR_DEVICE_LOST` or a silent crash,
+>   the GPU shared memory ceiling (§2.3) may need to be set higher — the
+>   default registry value is often insufficient for this configuration.
+> - **Higher inference steps** (50+): XPU memory accumulates across the
+>   denoising loop; confirm stability at the default 20 steps before increasing.
+>
+> Other options:
+> - `--num-samples 3` for a quicker comparison with fewer samples.
+> - Monitor with `python templates\monitor_xpu_memory.py` from a second terminal.
+
+### 9.3 Visual evaluation checklist
+
+When inspecting the base vs. LoRA outputs, apply these three questions for
+each sample. They align with established image-editing evaluation dimensions: ⁴
+
+| Dimension | Question to ask |
+|---|---|
+| **Instruction adherence** | Does the LoRA output follow the edit prompt? (e.g., for "Add the character to the image" — is the character present in the right place?) |
+| **Edit quality** | Does the edit look natural and seamless? (no obvious artefacts, blurring, or inconsistency at edit boundaries) |
+| **Detail preservation** | Are unedited regions unchanged between base and LoRA outputs? (background, non-target areas should look identical) |
+
+A successful LoRA should pass all three on most samples. Failure patterns:
+- **No change**: base and LoRA outputs are identical → training had no effect; check loss trajectory and training steps.
+- **Instruction ignored**: character not added, wrong edit → LoRA learned something unrelated; check prompt consistency in dataset.
+- **Degraded quality**: artefacts, color shifts, garbled regions → possible overfitting or learning rate too high.
+
+---
+⁴ ImgEdit (Ye et al., arXiv:2505.20275, May 2025), https://github.com/PKU-YuanGroup/ImgEdit. Introduces instruction adherence, editing quality, and detail preservation as the three evaluation dimensions for image editing; adopted here as a manual inspection framework. Evaluates image editing models generally, not specifically qwen-image-finetune.
+
+## 10. Troubleshooting
+
+Patterns specific to qwen-image-edit NF4 QLoRA training on Intel AI PC.
+
+### 10.1 `RuntimeError: Expected all tensors to be on the same device`
+
+The framework has a `torch.cuda.current_device()` call that was not replaced
+with a device-agnostic wrapper (§6.1). Run the §6.2 scan to locate it and
+replace with the appropriate `device_utils.py` helper or an explicit
+`.to(self.accelerator.device)` call.
+
+### 10.2 `torch.xpu.memory_allocated()` returns 0 during training
+
+Two distinct causes:
+- The framework has a direct `torch.cuda.memory_allocated()` call that was
+  not replaced with a `device_utils` wrapper — run the §6.2 scan, locate it,
+  and replace with `torch.xpu.memory_allocated()` guarded by
+  `if torch.xpu.is_available()`.
+- (NF4 + LoRA flow) the trainer moves the model to CPU before LoRA injection
+  and never moves it back. Check `src/qflux/trainer/base_trainer.py` for
+  `.to("cpu")` calls before `get_peft_model(...)`. If found, add an explicit
+  `.to(self.accelerator.device)` after LoRA injection.
+
+### 10.3 Flash Attention 2 not available
+
+`attn_implementation="flash_attention_2"` in `from_pretrained` calls or
+in `config.json` will fail — `flash_attn` is a CUDA-only extension. Replace
+with `"sdpa"` (see §6.2).
+
+### 10.4 Stale Triton cache after version change
+
+After upgrading oneAPI, `torch+xpu`, or any `triton*` package, Triton may
+load kernels compiled against the old version and fail. Typical symptoms:
+`RuntimeError` during the first `Adam8bit.step()` or `quantize_4bit`, or a
+confusing kernel-binary-format error in the traceback.
+
+**Always clear both caches after any version change before the next training
+run:**
+
+```bat
+rmdir /s /q "%USERPROFILE%\.triton"
+rmdir /s /q "%LOCALAPPDATA%\Temp\torchinductor_%USERNAME%"
+```
+
+Both directories are safe to delete — they rebuild automatically on the next
+Triton-backed op. If `rmdir` fails because a process holds the directory,
+close all Python / training processes first.
+
+### 10.5 `accelerator.device` is `cuda:0` instead of `xpu:0`
+
+**Most common cause**: `accelerate_config_xpu.yaml` (§6.3) is not being
+passed to `accelerate launch`, or the config file contains
+`distributed_type: MULTI_GPU` instead of `NO`.
+
+**Fix**: confirm the launcher passes `--config_file accelerate_config_xpu.yaml`
+and the config has `distributed_type: NO` and `use_cpu: false`.
+
+**Fallback for older accelerate versions** that lack native XPU device
+detection (accelerate < 0.27):
+
+```python
+# After Accelerator() construction, force the device if detection failed:
+if torch.xpu.is_available() and accelerator.device.type != "xpu":
+    accelerator.state.device = torch.device("xpu:0")
+```
+
+### 10.6 `KeyError: Invalid key: 0` — `load_dataset` returned a `DatasetDict`
+
+`load_dataset(name)` without a `split=` argument returns a `DatasetDict`.
+Integer indexing or `len()` on it then fails (only string keys accepted).
+
+Fix:
+
+```python
+from datasets import DatasetDict, load_dataset
+
+dataset = load_dataset(dataset_name)
+if isinstance(dataset, DatasetDict):
+    split = "train" if "train" in dataset else next(iter(dataset))
+    dataset = dataset[split]
+```
+
+### 10.7 Inference `TypeError: unsupported operand type for //: 'NoneType' and 'int'`
+
+**Trigger**: calling `templates/inference_compare.py` without passing `height`
+and `width` to `trainer.predict()`, so the trainer's `prepare_embeddings` path
+receives `batch["height"] = None`.
+
+**Fix** (already applied in the bundled `templates/inference_compare.py`):
+derive height/width from the first control image before calling `predict()`:
+
+```python
+ctrl_w, ctrl_h = s["control_images"][0].size  # PIL.size = (width, height)
+out_imgs = trainer.predict(..., height=ctrl_h, width=ctrl_w, ...)
+```
+
+If you see this in a custom inference script, apply the same pattern.
+
+### 10.8 Inference `ValueError: offline mode — must specify weight_name`
+
+**Trigger**: loading a LoRA checkpoint when `HF_HUB_OFFLINE=1` is set,
+because `diffusers.load_lora_adapter()` calls `_best_guess_weight_name()`
+which raises immediately in offline mode even for local file paths.
+
+**Fix** (already applied in `qflux/trainer/base_trainer.py`): if
+`pretrained_weight` ends in `.safetensors`, extract the parent directory and
+filename, and pass `weight_name` explicitly to `load_lora_adapter()`. If you
+are running a version of qflux that does not have this fix, either:
+
+- Upgrade to a version that includes the fix, or
+- Pass the checkpoint directory (not the full file path) and ensure the
+  filename is `pytorch_lora_weights.safetensors` (PEFT default).
+
+### 10.9 Cache-phase out-of-memory on tighter RAM tiers
+
+If the cache phase (§8.2) hits OOM or the system swaps heavily, the cause
+is usually that the bf16 text_encoder (~15 GB) plus dataset plus OS
+overhead exceeds the available system RAM ceiling. On 32 GB machines this
+is on the edge; 16 GB is over budget.
+
+Mitigations, in order of effort:
+1. Confirm §2.3 GPU shared memory ceiling has been raised — gives the
+   iGPU more room.
+2. Reduce dataset size for the first run (cache fewer samples; verify
+   the rest of the pipeline before scaling up).
+3. Use §7.2 NF4 text_encoder (validated): run `templates\launchers\quantize_text_encoder_xpu.bat`
+   once and set `model.text_encoder_path` in config — reduces cache-phase RAM
+   by ~8 GB, eliminating the paging bottleneck.
+4. Run cache phase on a CPU-only pass (slower but uses less peak RAM):
+   set `cache.devices.text_encoder: cpu` in the YAML.
+
+### 10.10 Triton package errors (wrong package installed)
+
+If you see Triton-related errors (`ImportError`, `RuntimeError` on first
+kernel execution, or driver-conflict crashes) that persist after clearing
+caches (§10.4), the environment may have the wrong Triton package — for
+example `triton` (NVIDIA-targeting) or `triton-windows` installed alongside
+`pytorch-triton-xpu` or `triton-xpu`.
+
+**Fix**: uninstall all Triton variants, then reinstall only the correct one
+for your `torch+xpu` version (see §2.7 version table):
+
+```bat
+pip uninstall triton pytorch-triton pytorch-triton-xpu triton-xpu triton-windows -y
+REM Then install the correct package, e.g. for torch 2.11.0+xpu:
+pip install triton-xpu==3.7.*
+```
+
+After reinstalling, clear the Triton caches (§10.4) before the next run.
+
+### 10.11 Triton kernel compilation fails — Level Zero headers missing
+
+If Triton-backed ops (`quantize_4bit`, `Adam8bit.step()`) fail with a Level
+Zero-related error or `RuntimeError: Failed to find C compiler...`, Triton
+cannot locate the Level Zero SDK headers it needs to JIT-compile kernels.
+
+`templates/probe_hw.py` reports `"level_zero_sdk": null` when this is the
+case.
+
+**Check first** — the GPU driver may have already set `LEVEL_ZERO_V1_SDK_PATH`:
+
+```bat
+echo %LEVEL_ZERO_V1_SDK_PATH%
+```
+
+If it prints a real directory containing `include\level_zero\ze_api.h`,
+you're done — this is not the issue.
+
+**If null**, download the Level Zero SDK manually and set `ZE_PATH`:
+
+1. Download `level-zero-win-sdk-<version>.zip` from
+   https://github.com/oneapi-src/level-zero/releases (match the version
+   compatible with your GPU driver's Level Zero loader).
+2. Extract to a path with no spaces or non-ASCII characters.
+3. Set `ZE_PATH` to the extracted directory (the one containing `include/`
+   and `lib/`) **before** calling `setvars.bat`:
+
+   ```bat
+   set ZE_PATH=C:\path\to\level-zero-sdk
+   call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+   ```
+
+4. Add this `set ZE_PATH=...` line to your training launcher so it is set
+   on every run.
+
+### 10.12 Machine reboots unexpectedly during training
+
+**Symptom**: the machine restarts without a BSOD or error log during
+training — especially under high memory or XPU utilization. Can also
+manifest as a hard hang followed by reboot.
+
+**Known cause and fix**: outdated Intel Arc Graphics driver. Install the
+latest version from:
+
+https://www.intel.com/content/www/us/en/download/785597/intel-arc-graphics-windows.html
+
+Driver stability under sustained XPU load improved significantly in recent
+releases. After installing, reboot as prompted.
+
+**After the reboot — re-verify the shared GPU memory setting**: driver
+installation can reset certain registry values. Re-check that
+`SystemPartitionCommitLimitPercentage` is still set to your target value
+(e.g. 75) by opening Registry Editor and navigating to:
+
+```
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\MemoryManager
+```
+
+If it has reverted to the default (~57), re-apply the setting per §2.3 and
+reboot again.
+
+## 11. End-to-end Walkthrough
+
+Sequence the agent runs once §2 pre-flight is human-confirmed. Each step
+has a machine-judgable PASS signal; if a step fails, the agent should stop
+and report rather than proceed — a silently-failed cache phase will surface
+as confusing errors during fit, much costlier to debug.
+
+| # | Step | Command | PASS signal |
+|---|---|---|---|
+| 1 | §3 dataset validate | `python templates/dataset_validate.py <path>` | exit 0; `valid: true` in JSON |
+| 2 | §4 env active | `python templates/probe_hw.py` | `xpu_available: true`; `torch_version` ends `+xpu`; `bnb_xpu_available: true` |
+| 3 | §5 recommend | `python templates/probe_hw.py \| python templates/recommend_config.py --out config.yaml --dataset-path <path>` | `config.yaml` parses; selected §7 patterns printed to stderr |
+| 4 | §6 adaptation applied | run the §6.7 import-test | `[OK] all modified modules imported cleanly` |
+| 5 | §7.1 pre-quantize transformer (if selected) | `templates\launchers\quantize_xpu.bat <pipeline> <nf4-out>` | Output dir has `config.json` with `quantization_config` field; ~10 GB total |
+| 5.5 | §7.2 pre-quantize text_encoder (**32 GB machines only**) | `templates\launchers\quantize_text_encoder_xpu.bat <pipeline> <nf4-te-out>` | Output dir has `config.json` with `quantization_config` field; ~5.5 GB total |
+| 6 | §7 patterns applied to YAML | inspect `config.yaml` | All keys from §5.1 tier table for the user's RAM tier present; `text_encoder_path` set if 32 GB machine |
+| 7 | §8.2 cache phase | `templates\launchers\train_xpu.bat <config> --cache` | exit 0; `cache.cache_dir` contains per-sample subdirs |
+| 8 | §8.3 fit step 1 | `templates\launchers\train_xpu.bat <config>` (first step may take longer as Triton JIT compiles) | Step completes; `xpu.memory_allocated() > 0`; loss finite |
+| 9 | §8.3 fit to completion | continue from step 1 | Final loss meaningfully below initial; checkpoints written |
+| 10 | §9 validate LoRA | Run `templates/inference_compare.py` twice (base + lora per §9.2); inspect outputs with §9.3 visual checklist | LoRA outputs visibly differ from base outputs; apply §9.3 checklist to judge direction and quality of the change |
+
+For a small dataset (~30 samples), use **smooth loss** rather than per-step
+raw loss to judge convergence — raw loss is noisy on small datasets due to
+repeated batches. A sustained downward trend in smooth loss is the key signal,
+regardless of the absolute values.
+
+If resuming training from a checkpoint, note that the cosine LR schedule
+restarts from its initial value, which can cause smooth loss to temporarily
+rise before continuing to decrease. This is expected behavior, not a sign of
+instability.
+
+If the run fails at step 8 with near-zero XPU memory, check §10.2 — the
+trainer may be running on CPU (likely a §6 adaptation issue). Check before
+suspecting anything else.

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/README.md
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/README.md
@@ -1,0 +1,20 @@
+# templates/
+
+Scripts and launchers the agent runs as part of the SKILL.md workflow.
+
+| File | SKILL.md | Purpose |
+|---|---|---|
+| `probe_hw.py` | §5 | Probe XPU / RAM / oneAPI; emit JSON to stdout (consumed by `recommend_config.py`) |
+| `recommend_config.py` | §5 | Read probe JSON → emit a training YAML + list of §7 patterns to apply |
+| `dataset_validate.py` | §3 | Sanity-check dataset format + sample count before training |
+| `quantize_transformer_nf4.py` | §7.1 | One-time NF4 pre-quantization of the DiT transformer |
+| `quantize_text_encoder_nf4.py` | §7.2 | One-time NF4 pre-quantization of the text_encoder |
+| `inference_compare.py` | §9.2 | Run inference on a test split (base + LoRA); saves PNGs + `manifest.json` for visual comparison |
+| `monitor_xpu_memory.py` | §5.1 / §9.2 | Poll XPU memory at a fixed interval; run from a second terminal during training or inference |
+| `launchers/quantize_xpu.bat` | §7.1 | Windows launcher for transformer NF4 quantization (handles oneAPI + conda activation) |
+| `launchers/quantize_text_encoder_xpu.bat` | §7.2 | Windows launcher for text_encoder NF4 quantization |
+| `launchers/train_xpu.bat` | §8 | Windows launcher: oneAPI `setvars.bat` + `conda activate` + `accelerate launch` / `--cache` mode |
+
+All scripts use only stdlib + commonly-installed deps (torch, transformers,
+psutil where applicable). Each script's docstring documents its CLI and
+expected outputs in detail.

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/dataset_validate.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/dataset_validate.py
@@ -1,0 +1,258 @@
+"""Validate a dataset for qwen-image-edit fine-tuning.
+
+Detects the user's dataset format (local dir / HuggingFace parquet / CSV)
+and runs format-appropriate checks BEFORE the user commits to a training
+run. Outputs a JSON verdict.
+
+Tested against the schema of `qflux.data.dataset.ImageDataset` and the
+TsienDragon/character-composition dataset.
+
+Usage:
+    python templates/dataset_validate.py <dataset-path>
+
+Examples:
+    python templates/dataset_validate.py <path/to/local-dataset>
+    python templates/dataset_validate.py <path/to/dataset.csv>
+    python templates/dataset_validate.py <path/to/hf-parquet-dir>
+
+Output (stdout): JSON verdict.
+Exit code: 0 if valid, 1 otherwise.
+
+Network policy: this script DOES NOT fetch remote HuggingFace repos. For a
+remote `owner/repo` argument, it only sanity-checks the format string and
+emits a warning recommending verification via `max_train_steps=1`.
+"""
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+IMG_EXTS = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
+
+IMAGE_DIR_NAMES = ["training_images", "images", "target_images", "target", "targets"]
+CONTROL_DIR_NAMES = ["control_images", "control", "condition_images", "controls"]
+
+CONTROL_EXTRA_PATTERN = re.compile(r"_control_(\d+)\.(?:png|jpe?g|webp|bmp)$", re.IGNORECASE)
+MASK_PATTERN = re.compile(r"_mask\.png$", re.IGNORECASE)
+
+
+def detect_format(dataset_path: str) -> str:
+    p = Path(dataset_path)
+    if str(dataset_path).lower().endswith(".csv"):
+        return "csv"
+    if p.is_dir():
+        if (p / "data").exists() and any((p / "data").glob("*.parquet")):
+            return "huggingface"
+        return "local"
+    if "/" in str(dataset_path) and not p.exists():
+        return "huggingface"
+    return "unknown"
+
+
+def _size_assessment(count: int) -> tuple[list, list]:
+    """Return (issues, warnings) for the sample count."""
+    issues, warnings = [], []
+    if count < 5:
+        issues.append(
+            f"Sample count {count} below the hard floor of 5; pipeline cannot meaningfully train."
+        )
+    elif count < 10:
+        warnings.append(
+            f"Sample count {count} is in smoke-test territory (5-9); "
+            "expect rapid overfitting within ~100 steps."
+        )
+    elif count < 30:
+        warnings.append(
+            f"Sample count {count} below recommended baseline of 30; "
+            "expect mild quality variance for single-concept LoRA."
+        )
+    return issues, warnings
+
+
+def validate_local(path: Path) -> dict:
+    issues, warnings = [], []
+
+    images_dir = next((path / n for n in IMAGE_DIR_NAMES if (path / n).exists()), None)
+    if images_dir is None:
+        return {
+            "valid": False, "format": "local", "sample_count": 0,
+            "issues": [f"No images directory found. Expected one of {IMAGE_DIR_NAMES} under {path}"],
+            "warnings": [],
+        }
+
+    control_dir = next((path / n for n in CONTROL_DIR_NAMES if (path / n).exists()), None)
+    if control_dir is None:
+        return {
+            "valid": False, "format": "local", "sample_count": 0,
+            "issues": [f"No control directory found. Expected one of {CONTROL_DIR_NAMES} under {path}"],
+            "warnings": [],
+        }
+
+    targets = []
+    for f in images_dir.iterdir():
+        if not f.is_file() or f.suffix.lower() not in IMG_EXTS:
+            continue
+        if MASK_PATTERN.search(f.name) or CONTROL_EXTRA_PATTERN.search(f.name):
+            continue
+        targets.append(f)
+
+    if not targets:
+        issues.append(f"No target images found in {images_dir}")
+        return {"valid": False, "format": "local", "sample_count": 0,
+                "issues": issues, "warnings": warnings}
+
+    paired = 0
+    no_control, no_prompt = [], []
+    for t in targets:
+        stem = t.stem
+        has_control = any(
+            (control_dir / f"{stem}{ext}").exists() for ext in IMG_EXTS
+        )
+        if not has_control:
+            no_control.append(stem)
+            continue
+        has_prompt = (images_dir / f"{stem}.txt").exists() or (control_dir / f"{stem}.txt").exists()
+        if not has_prompt:
+            no_prompt.append(stem)
+            continue
+        paired += 1
+
+    if no_control:
+        sample = no_control[:5]
+        issues.append(
+            f"{len(no_control)} target images have no matching control: "
+            f"{sample}{' ...' if len(no_control) > 5 else ''}"
+        )
+    if no_prompt:
+        sample = no_prompt[:5]
+        issues.append(
+            f"{len(no_prompt)} samples have no prompt .txt file: "
+            f"{sample}{' ...' if len(no_prompt) > 5 else ''}"
+        )
+
+    size_issues, size_warnings = _size_assessment(paired)
+    issues.extend(size_issues)
+    warnings.extend(size_warnings)
+
+    return {
+        "valid": len(issues) == 0,
+        "format": "local",
+        "sample_count": paired,
+        "issues": issues,
+        "warnings": warnings,
+    }
+
+
+def validate_csv(path: Path) -> dict:
+    issues, warnings = [], []
+    try:
+        with open(path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            cols = list(reader.fieldnames or [])
+            rows = list(reader)
+    except Exception as e:
+        return {"valid": False, "format": "csv", "sample_count": 0,
+                "issues": [f"Failed to read CSV: {e}"], "warnings": []}
+
+    required = ["path_target", "prompt"]
+    missing = [c for c in required if c not in cols]
+    if missing:
+        issues.append(f"Missing required columns: {missing}")
+
+    control_cols = [c for c in cols if "path_control" in c]
+    if not control_cols:
+        issues.append("No path_control* columns found")
+
+    size_issues, size_warnings = _size_assessment(len(rows))
+    issues.extend(size_issues)
+    warnings.extend(size_warnings)
+
+    return {
+        "valid": len(issues) == 0,
+        "format": "csv",
+        "sample_count": len(rows),
+        "issues": issues,
+        "warnings": warnings,
+    }
+
+
+def validate_huggingface(repo_or_path: str) -> dict:
+    issues, warnings = [], []
+    sample_count = -1
+
+    p = Path(repo_or_path)
+    if p.is_dir():
+        parquets = list((p / "data").glob("*.parquet"))
+        if not parquets:
+            return {"valid": False, "format": "huggingface", "sample_count": 0,
+                    "issues": [f"Local dir {p} has no data/*.parquet files"],
+                    "warnings": []}
+        try:
+            import pandas as pd
+            df = pd.read_parquet(parquets[0])
+            cols = df.columns.tolist()
+            required = ["target_image", "control_images", "prompt"]
+            missing = [c for c in required if c not in cols]
+            if missing:
+                issues.append(
+                    f"Missing required columns in parquet: {missing} (need {required})"
+                )
+            sample_count = len(df)
+            size_issues, size_warnings = _size_assessment(sample_count)
+            issues.extend(size_issues)
+            warnings.extend(size_warnings)
+        except ImportError:
+            warnings.append("pandas not available; could not inspect parquet schema")
+            sample_count = len(parquets)
+    else:
+        if "/" not in repo_or_path:
+            issues.append(
+                f"Not a valid HF repo id (need 'owner/name' format): {repo_or_path}"
+            )
+        else:
+            warnings.append(
+                f"Remote HF repo '{repo_or_path}' — schema validation requires "
+                "network (skill's local-only policy disallows). Verify by "
+                "running training once with max_train_steps=1."
+            )
+
+    return {
+        "valid": len(issues) == 0,
+        "format": "huggingface",
+        "sample_count": sample_count,
+        "issues": issues,
+        "warnings": warnings,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Validate a dataset for qwen-image-edit fine-tuning."
+    )
+    p.add_argument("dataset_path",
+                   help="Local dir, HuggingFace repo id, or .csv file path")
+    args = p.parse_args()
+
+    fmt = detect_format(args.dataset_path)
+    if fmt == "local":
+        result = validate_local(Path(args.dataset_path))
+    elif fmt == "huggingface":
+        result = validate_huggingface(args.dataset_path)
+    elif fmt == "csv":
+        result = validate_csv(Path(args.dataset_path))
+    else:
+        result = {
+            "valid": False, "format": "unknown", "sample_count": 0,
+            "issues": [f"Could not detect format for {args.dataset_path}"],
+            "warnings": [],
+        }
+
+    print(json.dumps(result, indent=2))
+    sys.exit(0 if result["valid"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/inference_compare.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/inference_compare.py
@@ -1,0 +1,192 @@
+"""Run inference on a test split with and without LoRA for visual comparison.
+
+Run twice with the same config — once for the base model, once with LoRA weights.
+Inspect the outputs side-by-side using the §9.3 visual evaluation checklist.
+
+Usage:
+    # Step 1 — base model (no LoRA)
+    python templates/inference_compare.py \\
+        --config <path/to/config.yaml> \\
+        --test-parquet <path/to/test.parquet> \\
+        --output-dir outputs/compare/<run>/base \\
+        --num-samples 5
+
+    # Step 2 — LoRA-applied
+    python templates/inference_compare.py \\
+        --config <path/to/config.yaml> \\
+        --test-parquet <path/to/test.parquet> \\
+        --output-dir outputs/compare/<run>/lora \\
+        --num-samples 5 \\
+        --lora-weight outputs/<run>/checkpoint-<step>/pytorch_lora_weights.safetensors
+
+Output per directory:
+    sample_NN_<id>.png          — model output for each test sample
+    sample_NN_<id>__target.png  — ground-truth target (if present in dataset)
+    manifest.json               — metadata (prompts, paths, any errors)
+
+Prerequisite: run from within the qwen-image-finetune project root, with the
+qflux package importable. Set PYTHONPATH to include the project's `src/`
+directory, or run from inside `src/` directly.
+
+Network policy: this script does NOT touch the network. All models and data
+must already be on disk. Run with HF_HUB_OFFLINE=1 etc. in your launcher.
+
+(Adapted from scripts/inference_compare.py in the qwen-image-finetune project)
+"""
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+
+import PIL.Image
+import pyarrow.parquet as pq
+import torch
+
+from qflux.data.config import Config, TrMode, load_config_from_yaml
+
+try:
+    from qflux.utils.memory_probe import MemoryProbe
+except ImportError:
+    MemoryProbe = None
+
+
+def _read_test_samples(parquet_path: Path, n: int) -> list:
+    """Pull first n rows from a test parquet file."""
+    table = pq.read_table(parquet_path)
+    rows = table.slice(0, n).to_pylist()
+    samples = []
+    for i, row in enumerate(rows):
+        ctrl_imgs = []
+        for entry in row.get("control_images") or []:
+            if isinstance(entry, dict) and "bytes" in entry and entry["bytes"]:
+                ctrl_imgs.append(PIL.Image.open(io.BytesIO(entry["bytes"])).convert("RGB"))
+            elif isinstance(entry, (bytes, bytearray)):
+                ctrl_imgs.append(PIL.Image.open(io.BytesIO(entry)).convert("RGB"))
+        target_entry = row.get("target_image")
+        tgt = None
+        if isinstance(target_entry, dict) and target_entry.get("bytes"):
+            tgt = PIL.Image.open(io.BytesIO(target_entry["bytes"])).convert("RGB")
+        samples.append({
+            "id": row.get("id", str(i)),
+            "control_images": ctrl_imgs,
+            "target_image": tgt,
+            "prompt": row.get("prompt", ""),
+        })
+    return samples
+
+
+def _instantiate_trainer(config: Config):
+    if config.trainer_type == "QwenImageEdit":
+        from qflux.trainer.qwen_image_edit_trainer import QwenImageEditTrainer
+        return QwenImageEditTrainer(config)
+    raise NotImplementedError(
+        f"inference_compare.py supports QwenImageEdit only, got {config.trainer_type}"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Run inference on a test split for visual LoRA comparison."
+    )
+    p.add_argument("--config", required=True,
+                   help="Path to training config YAML")
+    p.add_argument("--test-parquet", required=True,
+                   help="Path to test split parquet file")
+    p.add_argument("--output-dir", required=True,
+                   help="Directory to write output images and manifest.json")
+    p.add_argument("--num-samples", type=int, default=5,
+                   help="Number of test samples to run (default: 5)")
+    p.add_argument("--num-inference-steps", type=int, default=20,
+                   help="Diffusion inference steps (default: 20)")
+    p.add_argument("--lora-weight", default=None,
+                   help="Path to pytorch_lora_weights.safetensors; omit for base model")
+    p.add_argument("--seed", type=int, default=42,
+                   help="Fixed seed for reproducibility (default: 42)")
+    args = p.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    config = load_config_from_yaml(args.config)
+    # Inference mode: force text_encoder load (needed for new prompts) and
+    # disable cache-first optimization (cache embeddings are training-time only)
+    config.mode = TrMode.fit
+    config.cache.use_cache = False
+    config.data.init_args.use_cache = False
+    config.validation.enabled = False
+    # Keep text_encoder on CPU to avoid XPU memory pressure during inference
+    config.predict.devices.text_encoder = "cpu"
+
+    if args.lora_weight:
+        config.model.lora.pretrained_weight = args.lora_weight
+        print(f"[inference_compare] LoRA mode: {args.lora_weight}")
+    else:
+        config.model.lora.pretrained_weight = None
+        print("[inference_compare] Base model mode (no LoRA)")
+
+    samples = _read_test_samples(Path(args.test_parquet), args.num_samples)
+    print(f"[inference_compare] Loaded {len(samples)} test samples")
+
+    torch.manual_seed(args.seed)
+
+    label = "lora" if args.lora_weight else "base"
+
+    def _run():
+        trainer = _instantiate_trainer(config)
+        trainer.setup_predict()
+        manifest = {
+            "mode": label,
+            "lora_weight": args.lora_weight,
+            "config": args.config,
+            "num_inference_steps": args.num_inference_steps,
+            "seed": args.seed,
+            "samples": [],
+        }
+        for i, s in enumerate(samples):
+            sid = s["id"]
+            print(f"[inference_compare] {i + 1}/{len(samples)}: id={sid}")
+            try:
+                # Derive height/width from the first control image so the
+                # trainer's prepare_embeddings path receives non-None values.
+                # (PIL.Image.size returns (width, height))
+                ctrl_w, ctrl_h = s["control_images"][0].size
+                out_imgs = trainer.predict(
+                    image=s["control_images"],
+                    prompt=s["prompt"],
+                    height=ctrl_h,
+                    width=ctrl_w,
+                    num_inference_steps=args.num_inference_steps,
+                )
+                out_img = out_imgs[0] if isinstance(out_imgs, list) else out_imgs
+                fname = f"sample_{i:02d}_{sid}.png"
+                out_img.save(out_dir / fname)
+                if s["target_image"] is not None:
+                    s["target_image"].save(out_dir / f"sample_{i:02d}_{sid}__target.png")
+                manifest["samples"].append({
+                    "id": sid,
+                    "prompt": s["prompt"],
+                    "output": fname,
+                    "has_target": s["target_image"] is not None,
+                })
+            except Exception as e:
+                import traceback
+                print(f"[inference_compare] sample {i} FAILED: {e}")
+                manifest["samples"].append({
+                    "id": sid,
+                    "error": f"{type(e).__name__}: {e}",
+                    "traceback": traceback.format_exc(),
+                })
+        with open(out_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+        print(f"[inference_compare] Done. Output: {out_dir}")
+
+    if MemoryProbe is not None:
+        with MemoryProbe(label=f"inference-{label}"):
+            _run()
+    else:
+        _run()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/quantize_text_encoder_xpu.bat
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/quantize_text_encoder_xpu.bat
@@ -1,0 +1,59 @@
+@echo off
+REM templates/launchers/quantize_text_encoder_xpu.bat
+REM
+REM One-time NF4 pre-quantization of the Qwen2.5-VL text_encoder.
+REM Wraps templates/quantize_text_encoder_nf4.py with oneAPI activation.
+REM
+REM Usage:
+REM   quantize_text_encoder_xpu.bat <src-pipeline-dir> <dst-nf4-dir>
+REM
+REM Example:
+REM   quantize_text_encoder_xpu.bat C:\models\Qwen-Image-Edit-2511 C:\models\Qwen-Image-Edit-2511-nf4-text-encoder
+REM
+REM After completion, set model.text_encoder_path in your training config.
+REM Prerequisites: §2 pre-flight done; §4 conda env created.
+
+setlocal
+
+if "%~1"=="" (
+    echo ERROR: source pipeline directory required.
+    echo Usage: quantize_text_encoder_xpu.bat ^<src^> ^<dst^>
+    exit /b 1
+)
+if "%~2"=="" (
+    echo ERROR: destination directory required.
+    echo Usage: quantize_text_encoder_xpu.bat ^<src^> ^<dst^>
+    exit /b 1
+)
+
+set SRC=%~1
+set DST=%~2
+
+REM NoDefaultCurrentDirectoryInExePath guards against DLL loading from
+REM the current directory. Cleared only for Intel oneAPI setvars.bat;
+REM restored below — DO NOT remove the restore line.
+set "NoDefaultCurrentDirectoryInExePath="
+REM Default oneAPI install path — update this line if installed elsewhere.
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+set "NoDefaultCurrentDirectoryInExePath=1"
+if errorlevel 1 (
+    echo ERROR: setvars.bat failed
+    exit /b 1
+)
+
+REM Activate conda env
+call conda activate qwen-image-edit-xpu
+if errorlevel 1 (
+    echo ERROR: conda activate failed — expected env name 'qwen-image-edit-xpu'
+    exit /b 1
+)
+
+set QFLUX_DOTENV_LOADED=1
+set PYTHONUTF8=1
+set SYCL_CACHE_PERSISTENT=1
+
+echo [quantize_te] Quantizing text_encoder: %SRC% ^→ %DST%
+python templates\quantize_text_encoder_nf4.py --src "%SRC%" --dst "%DST%"
+
+echo [quantize_te] Done. Exit code: %ERRORLEVEL%
+endlocal

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/quantize_xpu.bat
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/quantize_xpu.bat
@@ -1,0 +1,59 @@
+@echo off
+REM templates/launchers/quantize_xpu.bat
+REM
+REM One-time NF4 pre-quantization of the Qwen-Image-Edit transformer (DiT).
+REM Wraps templates/quantize_transformer_nf4.py with oneAPI activation.
+REM
+REM Usage:
+REM   quantize_xpu.bat <src-pipeline-dir> <dst-nf4-dir>
+REM
+REM Example:
+REM   quantize_xpu.bat C:\models\Qwen-Image-Edit-2511 C:\models\Qwen-Image-Edit-2511-nf4-transformer
+REM
+REM After completion, set model.transformer_path in your training config.
+REM Prerequisites: §2 pre-flight done; §4 conda env created.
+
+setlocal
+
+if "%~1"=="" (
+    echo ERROR: source pipeline directory required.
+    echo Usage: quantize_xpu.bat ^<src^> ^<dst^>
+    exit /b 1
+)
+if "%~2"=="" (
+    echo ERROR: destination directory required.
+    echo Usage: quantize_xpu.bat ^<src^> ^<dst^>
+    exit /b 1
+)
+
+set SRC=%~1
+set DST=%~2
+
+REM NoDefaultCurrentDirectoryInExePath guards against DLL loading from
+REM the current directory. Cleared only for Intel oneAPI setvars.bat;
+REM restored below — DO NOT remove the restore line.
+set "NoDefaultCurrentDirectoryInExePath="
+REM Default oneAPI install path — update this line if installed elsewhere.
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+set "NoDefaultCurrentDirectoryInExePath=1"
+if errorlevel 1 (
+    echo ERROR: setvars.bat failed
+    exit /b 1
+)
+
+REM Activate conda env
+call conda activate qwen-image-edit-xpu
+if errorlevel 1 (
+    echo ERROR: conda activate failed — expected env name 'qwen-image-edit-xpu'
+    exit /b 1
+)
+
+set QFLUX_DOTENV_LOADED=1
+set PYTHONUTF8=1
+set SYCL_CACHE_PERSISTENT=1
+
+echo [quantize] Quantizing transformer: %SRC% → %DST%
+python templates\quantize_transformer_nf4.py --src "%SRC%" --dst "%DST%"
+
+echo [quantize] Done. Exit code: %ERRORLEVEL%
+endlocal

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/train_xpu.bat
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/launchers/train_xpu.bat
@@ -1,0 +1,71 @@
+@echo off
+REM templates/launchers/train_xpu.bat
+REM
+REM Launches qwen-image-edit fine-tuning on Intel XPU on Windows.
+REM Activates oneAPI runtime, conda env, and runs the training entry point.
+REM
+REM Usage:
+REM   train_xpu.bat <config-path> [--cache]
+REM     <config-path>: path to YAML config (typically output of recommend_config.py)
+REM     --cache:       optional. If present, runs in cache-build mode (one-time
+REM                    per dataset). Otherwise runs fit (training) mode.
+REM
+REM Example:
+REM   train_xpu.bat configs/my_run.yaml --cache
+REM   train_xpu.bat configs/my_run.yaml
+REM
+REM Prerequisites:
+REM   - SKILL.md §2 pre-flight done (oneAPI installed at default path)
+REM   - SKILL.md §4 conda env created (default name: qwen-image-edit-xpu)
+REM   - SKILL.md §6 framework adaptation applied to qwen-image-finetune
+REM
+REM This launcher assumes the conda env name is qwen-image-edit-xpu and the
+REM oneAPI install is at the Windows default path. Edit if your setup differs.
+
+setlocal
+
+if "%~1"=="" (
+    echo ERROR: config path required
+    echo Usage: train_xpu.bat ^<config^> [--cache]
+    exit /b 1
+)
+set CONFIG=%~1
+set MODE=%~2
+
+REM NoDefaultCurrentDirectoryInExePath guards against DLL loading from
+REM the current directory. Cleared only for Intel oneAPI setvars.bat;
+REM restored below — DO NOT remove the restore line.
+set "NoDefaultCurrentDirectoryInExePath="
+REM Default oneAPI install path — update this line if installed elsewhere.
+call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --force
+set "NoDefaultCurrentDirectoryInExePath=1"
+if errorlevel 1 (
+    echo ERROR: setvars.bat failed -- check oneAPI install path in this script
+    exit /b 1
+)
+
+REM Activate conda env
+call conda activate qwen-image-edit-xpu
+if errorlevel 1 (
+    echo ERROR: conda activate failed -- expected env name 'qwen-image-edit-xpu'
+    exit /b 1
+)
+
+REM Skip HF login on package import (assume token configured separately or
+REM model is on disk per pre-flight)
+set QFLUX_DOTENV_LOADED=1
+set PYTHONUTF8=1
+
+REM Cache compiled SYCL kernels for faster subsequent runs
+set SYCL_CACHE_PERSISTENT=1
+
+
+if /i "%MODE%"=="--cache" (
+    echo [train_xpu] cache-build mode
+    python -m qflux.main --config %CONFIG% --cache
+) else (
+    echo [train_xpu] fit mode
+    accelerate launch --config_file accelerate_config_xpu.yaml -m qflux.main --config %CONFIG%
+)
+
+endlocal

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/monitor_xpu_memory.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/monitor_xpu_memory.py
@@ -1,0 +1,68 @@
+"""Poll XPU memory allocation at a fixed interval.
+
+Run from a second terminal while training or inference is happening to
+confirm the XPU is actually being used and to track memory headroom.
+
+Usage:
+    python templates/monitor_xpu_memory.py
+    python templates/monitor_xpu_memory.py --interval 1.0
+    python templates/monitor_xpu_memory.py --count 10   # stop after 10 readings
+
+Output (one line per interval):
+    [21:05:03] XPU alloc: 15.77 GB  reserved: 17.05 GB  (21.80 GB capacity)
+"""
+import argparse
+import time
+from datetime import datetime
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Poll XPU memory allocation at a fixed interval."
+    )
+    p.add_argument(
+        "--interval",
+        type=float,
+        default=2.0,
+        help="Sampling interval in seconds (default: 2.0)",
+    )
+    p.add_argument(
+        "--count",
+        type=int,
+        default=0,
+        help="Number of readings before stopping; 0 = unlimited (default: 0)",
+    )
+    args = p.parse_args()
+
+    try:
+        import torch
+    except ImportError:
+        print("[monitor] torch is not installed in this environment.")
+        return
+
+    if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+        print("[monitor] XPU not available — nothing to monitor.")
+        return
+
+    props = torch.xpu.get_device_properties(0)
+    capacity_gb = props.total_memory / 1e9
+
+    i = 0
+    try:
+        while args.count == 0 or i < args.count:
+            ts = datetime.now().strftime("%H:%M:%S")
+            alloc = torch.xpu.memory_allocated(0) / 1e9
+            reserved = torch.xpu.memory_reserved(0) / 1e9
+            print(
+                f"[{ts}] XPU alloc: {alloc:.2f} GB  "
+                f"reserved: {reserved:.2f} GB  "
+                f"({capacity_gb:.2f} GB capacity)"
+            )
+            time.sleep(args.interval)
+            i += 1
+    except KeyboardInterrupt:
+        print("\n[monitor] stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/probe_hw.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/probe_hw.py
@@ -1,0 +1,188 @@
+"""Probe the local Intel AI PC hardware + key software components.
+
+Emits a JSON dict to stdout describing what's on this machine. Consumed by
+templates/recommend_config.py (T2) to pick a training config that fits.
+
+The output schema is the contract between probe_hw.py and recommend_config.py.
+Keep field names + types stable; add new fields rather than renaming.
+
+Schema:
+    {
+      "xpu_model":         str | null,   // e.g. "Intel(R) Arc(TM) 140V GPU"; null if no XPU
+      "xpu_available":     bool,         // torch.xpu.is_available()
+      "vram_gb":           float,        // get_device_properties(0).total_memory / 1e9
+      "ram_gb":            float,        // psutil.virtual_memory().total / 1e9
+      "ram_available_gb":  float,        // psutil.virtual_memory().available / 1e9
+      "oneapi_version":    str | null,   // probed from `icpx --version`, null if not on PATH
+      "conda_env":         str | null,   // CONDA_DEFAULT_ENV, null if not in conda
+      "bnb_version":       str | null,   // bitsandbytes.__version__, null if not installed
+      "bnb_xpu_available": bool,         // bnb has XPU backend module
+      "torch_version":     str | null,
+      "platform":          str,          // "windows" / "linux" / "darwin"
+      "level_zero_sdk":    str | null    // LEVEL_ZERO_V1_SDK_PATH or ZE_PATH if set, else null
+    }
+
+Usage:
+    python templates/probe_hw.py > probe.json
+    python templates/recommend_config.py --probe probe.json --out config.yaml
+
+Network policy: this script does NOT touch the network. All probes are local.
+
+(See bottom of file for a sample output captured at skill-authoring time.)
+"""
+import argparse
+import json
+import os
+import platform
+import re
+import subprocess
+
+
+def _probe_xpu():
+    info = {
+        "xpu_model": None,
+        "xpu_available": False,
+        "vram_gb": 0.0,
+        "torch_version": None,
+    }
+    try:
+        import torch
+        info["torch_version"] = torch.__version__
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            info["xpu_available"] = True
+            props = torch.xpu.get_device_properties(0)
+            info["xpu_model"] = props.name
+            info["vram_gb"] = round(props.total_memory / 1e9, 2)
+    except ImportError:
+        pass
+    return info
+
+
+def _probe_ram():
+    try:
+        import psutil
+        vm = psutil.virtual_memory()
+        return {
+            "ram_gb": round(vm.total / 1e9, 2),
+            "ram_available_gb": round(vm.available / 1e9, 2),
+        }
+    except ImportError:
+        try:
+            ram = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+            return {"ram_gb": round(ram / 1e9, 2), "ram_available_gb": -1.0}
+        except (ValueError, AttributeError):
+            return {"ram_gb": -1.0, "ram_available_gb": -1.0}
+
+
+def _probe_oneapi():
+    """Return the Intel oneAPI **toolkit** version (e.g. '2025.3').
+
+    Strategy:
+    1. Parse the InstalledDir path from `icpx --version` output, which
+       contains the two-part toolkit version: .../compiler/2025.3/...
+       This is more reliable than the three-part compiler build string
+       (e.g. 2025.3.3) that may differ slightly from the toolkit version.
+    2. Fall back to parsing the Compiler line and keeping major.minor only.
+
+    Requires `setvars.bat` to have been called (Windows) or oneAPI on PATH.
+    Returns None if icpx is not found.
+    """
+    try:
+        which = "where" if platform.system() == "Windows" else "which"
+        r = subprocess.run(
+            [which, "icpx"], capture_output=True, text=True, timeout=5
+        )
+        if r.returncode != 0:
+            return None
+        r2 = subprocess.run(
+            ["icpx", "--version"], capture_output=True, text=True, timeout=10
+        )
+        if r2.returncode != 0:
+            return None
+        output = r2.stdout + r2.stderr
+        # Primary: extract toolkit version from InstalledDir path
+        # e.g. "InstalledDir: C:\...\oneAPI\compiler\2025.3\bin\compiler"
+        m = re.search(r"[Ii]nstalled[Dd]ir.*[/\\]compiler[/\\](\d+\.\d+)[/\\]", output)
+        if m:
+            return m.group(1)
+        # Fallback: parse "Compiler X.X.X" and keep major.minor only
+        m = re.search(r"Compiler (\d+\.\d+)", output)
+        return m.group(1) if m else None
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _probe_conda():
+    return os.environ.get("CONDA_DEFAULT_ENV")
+
+
+def _probe_level_zero():
+    """Return the Level Zero SDK path if available, else None.
+
+    Triton XPU requires Level Zero headers to JIT-compile kernels.  They are
+    normally provided automatically by the GPU driver and discoverable via
+    LEVEL_ZERO_V1_SDK_PATH.  ZE_PATH is the manual fallback when the driver
+    did not set LEVEL_ZERO_V1_SDK_PATH (download from
+    https://github.com/oneapi-src/level-zero/releases and set ZE_PATH).
+
+    Returns the path of whichever variable is set (LEVEL_ZERO_V1_SDK_PATH
+    preferred), or None if neither is set.  A null value here means Triton
+    kernel compilation will likely fail — see §10.11 in SKILL.md.
+    """
+    for var in ("LEVEL_ZERO_V1_SDK_PATH", "ZE_PATH"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    return None
+
+
+def _probe_bnb():
+    info = {"bnb_version": None, "bnb_xpu_available": False}
+    try:
+        import bitsandbytes as bnb
+        info["bnb_version"] = bnb.__version__
+        try:
+            import bitsandbytes.backends.xpu  # noqa: F401
+            info["bnb_xpu_available"] = True
+        except ImportError:
+            pass
+    except ImportError:
+        pass
+    return info
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=(
+            "Probe Intel AI PC hardware + key software components. "
+            "Output is JSON consumed by recommend_config.py."
+        )
+    )
+    p.parse_args()
+
+    result = {
+        **_probe_xpu(),
+        **_probe_ram(),
+        "oneapi_version": _probe_oneapi(),
+        "conda_env": _probe_conda(),
+        **_probe_bnb(),
+        "platform": platform.system().lower(),
+        "level_zero_sdk": _probe_level_zero(),
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Output notes:
+# - vram_gb is the XPU-visible portion of unified memory; the system
+#   reserves the rest for OS/CPU. On 32 GB machines, psutil may report
+#   slightly more than the nominal 32 GB due to memory controller addressing.
+# - oneapi_version is null when probing from a shell where setvars.bat has
+#   not been called; recommend_config.py treats null as "not yet activated".
+# - bnb_xpu_available=true confirms the bitsandbytes XPU backend is
+#   compiled in (NF4 dequantize, gemv_4bit, etc.; see SKILL.md §6 / §7.4).
+# - level_zero_sdk: path set by the GPU driver or ZE_PATH env var.
+#   null here means Triton kernel compilation will likely fail — see §10.11.

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/quantize_text_encoder_nf4.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/quantize_text_encoder_nf4.py
@@ -1,0 +1,99 @@
+"""Pre-quantize the Qwen2.5-VL text_encoder to NF4 and save to disk.
+
+Run once per machine. After this, training cache phase loads the NF4 text_encoder
+directly — saves ~8 GB CPU RAM vs bf16 load, which is the margin that prevents
+the 31.5 GB ceiling crash on 32 GB AI PC machines.
+
+Trigger condition: `ram_gb <= 32`. See SKILL.md §7.2.
+
+Prerequisites: qflux Python package importable (clone qwen-image-finetune and
+either `pip install -e .` or run with the project's `src/` on PYTHONPATH).
+See SKILL.md §6 Framework Adaptation.
+
+Usage:
+    python templates/quantize_text_encoder_nf4.py \\
+        --src <path-to-qwen-image-edit-pipeline> \\
+        --dst <path-to-save-nf4-text-encoder>
+
+Example:
+    python templates/quantize_text_encoder_nf4.py \\
+        --src <path/to/Qwen-Image-Edit-pipeline> \\
+        --dst <path/to/Qwen-Image-Edit-nf4-text-encoder>
+
+On Windows, activate the oneAPI + conda env before running:
+    setvars.bat
+    conda activate qwen-image-edit-xpu
+
+After completion, set in your training config:
+    model:
+      text_encoder_path: <DST>
+The qflux model loader auto-detects quantization_config in <DST>/config.json
+and skips online quantization, avoiding the text_encoder bf16 CPU-RAM peak.
+
+Notes:
+- The text_encoder is Qwen2_5_VLForConditionalGeneration loaded from the
+  pipeline's `text_encoder/` subfolder (~15 GB bf16 on disk, ~7.5 GB NF4).
+- NF4 quantization requires bitsandbytes XPU backend and the oneAPI runtime.
+  Run setvars.bat before this script (Windows) or oneAPI on PATH (Linux).
+- On LNL 32 GB: text_encoder quantization runs on XPU (bitsandbytes auto-selects);
+  expect ~10 GB XPU peak during quantize + save.
+"""
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import BitsAndBytesConfig, Qwen2_5_VLForConditionalGeneration
+
+try:
+    from qflux.utils.memory_probe import MemoryProbe
+except ImportError:
+    MemoryProbe = None
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Pre-quantize Qwen2.5-VL text_encoder to NF4 (one-time)."
+    )
+    p.add_argument("--src", required=True,
+                   help="Source pipeline dir (contains text_encoder/ subfolder)")
+    p.add_argument("--dst", required=True,
+                   help="Destination dir for the NF4-quantized text_encoder")
+    p.add_argument("--compute-dtype", default="bfloat16",
+                   choices=["bfloat16", "float16"],
+                   help="bnb_4bit_compute_dtype (default: bfloat16)")
+    p.add_argument("--probe-interval", type=float, default=0.5,
+                   help="Memory sampling interval (seconds); ignored if MemoryProbe unavailable")
+    args = p.parse_args()
+
+    weight_dtype = getattr(torch, args.compute_dtype)
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype=weight_dtype,
+        bnb_4bit_use_double_quant=True,
+    )
+
+    def _quantize():
+        print(f"[quantize_te] streaming-load & quantize: {args.src}/text_encoder")
+        model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            args.src,
+            subfolder="text_encoder",
+            quantization_config=bnb_config,
+            torch_dtype=weight_dtype,
+        )
+        Path(args.dst).mkdir(parents=True, exist_ok=True)
+        print(f"[quantize_te] saving NF4 text_encoder to {args.dst}")
+        model.save_pretrained(args.dst, safe_serialization=True)
+        print(f'[quantize_te] done. Set in config:  model.text_encoder_path: "{args.dst}"')
+
+    if MemoryProbe is not None:
+        with MemoryProbe(interval=args.probe_interval, label="quantize_te"):
+            _quantize()
+    else:
+        print("[quantize_te] (qflux.utils.memory_probe not installed; running without probe)")
+        _quantize()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/quantize_transformer_nf4.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/quantize_transformer_nf4.py
@@ -1,0 +1,94 @@
+"""Pre-quantize the Qwen-Image-Edit transformer (DiT) to NF4 and save to disk.
+
+Run once per machine. After this, training loads the NF4 model directly:
+no bf16 CPU-RAM peak (~20 GB saved on a typical AI PC), 9.5 GB on disk.
+
+Trigger condition for using this script: see SKILL.md §7.1.
+
+Prerequisites: qflux Python package importable (clone qwen-image-finetune and
+either `pip install -e .` or run with the project's `src/` on PYTHONPATH).
+See SKILL.md §6 Framework Adaptation.
+
+Usage:
+    python templates/quantize_transformer_nf4.py \\
+        --src <path-to-qwen-image-edit-pipeline> \\
+        --dst <path-to-save-nf4-transformer>
+
+Example:
+    python templates/quantize_transformer_nf4.py \\
+        --src <path/to/Qwen-Image-Edit-pipeline> \\
+        --dst <path/to/Qwen-Image-Edit-nf4-transformer>
+
+On Windows, prefer the launcher (which activates oneAPI + conda):
+    templates/launchers/quantize_xpu.bat <SRC> <DST>
+
+bnb's Triton-backed quantize_4bit needs the oneAPI runtime to JIT-compile
+the quantize kernel — running without setvars.bat will fail.
+
+After completion, set in your training config:
+    model:
+      transformer_path: <DST>
+The qflux model loader auto-detects the saved `quantization_config` in
+`config.json` and skips online quantization on subsequent runs.
+"""
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import BitsAndBytesConfig
+
+from qflux.models.transformer_qwenimage import QwenImageTransformer2DModel
+
+try:
+    from qflux.utils.memory_probe import MemoryProbe
+except ImportError:
+    MemoryProbe = None
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Pre-quantize Qwen-Image-Edit transformer to NF4 (one-time)."
+    )
+    p.add_argument("--src", required=True,
+                   help="Source pipeline dir (contains transformer/ subfolder)")
+    p.add_argument("--dst", required=True,
+                   help="Destination dir for the NF4-quantized transformer")
+    p.add_argument("--compute-dtype", default="bfloat16",
+                   choices=["bfloat16", "float16"],
+                   help="bnb_4bit_compute_dtype (default: bfloat16)")
+    p.add_argument("--probe-interval", type=float, default=0.5,
+                   help="Memory sampling interval (seconds); ignored if MemoryProbe unavailable")
+    args = p.parse_args()
+
+    weight_dtype = getattr(torch, args.compute_dtype)
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype=weight_dtype,
+        bnb_4bit_use_double_quant=True,
+    )
+
+    def _quantize():
+        print(f"[quantize] streaming-load & quantize: {args.src}/transformer")
+        transformer = QwenImageTransformer2DModel.from_pretrained(
+            args.src,
+            subfolder="transformer",
+            quantization_config=bnb_config,
+            torch_dtype=weight_dtype,
+        )
+        Path(args.dst).mkdir(parents=True, exist_ok=True)
+        print(f"[quantize] saving NF4 weights to {args.dst}")
+        transformer.save_pretrained(args.dst, safe_serialization=True)
+        print(f'[quantize] done. Set in config:  model.transformer_path: "{args.dst}"')
+
+    if MemoryProbe is not None:
+        with MemoryProbe(interval=args.probe_interval, label="quantize"):
+            _quantize()
+    else:
+        print("[quantize] (qflux.utils.memory_probe not installed; running without probe)")
+        _quantize()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/qwen-image-edit-aipc-finetune/templates/recommend_config.py
+++ b/.claude/skills/qwen-image-edit-aipc-finetune/templates/recommend_config.py
@@ -1,0 +1,267 @@
+"""Recommend a training config given hardware probe output.
+
+Reads probe JSON (from probe_hw.py) and applies the rule table to emit a
+complete training YAML config that fits the user's machine.
+
+Rules applied (see SKILL.md §5.1 for the policy table):
+
+    Memory (NF4 + 8-bit optimizer):
+      ram_gb <= 64    → model.quantize_type = "nf4"          (NF4 transformer)
+      ram_gb <= 32    → recommend NF4 text_encoder (§7.2)
+      ram_gb <= 64    → optimizer = bitsandbytes.optim.Adam8bit
+    Resolution (default [384,672]; user can override for speed/quality):
+      [256, 448] — fast iteration: lower XPU demand, significantly faster per step
+      [384, 672] — balanced default (emitted by this script): moderate XPU demand
+      [512, 768] — full quality: higher XPU demand, tighter headroom on 32 GB AI PC,
+                   significantly slower per step; requires gradient_checkpointing=true
+      This script emits [384,672]; user can manually override in the output YAML.
+    Always-on for AI PC tier:
+      data.batch_size = 1
+      data.num_workers = 1                  (Windows spawn-mode)
+      train.mixed_precision = "no"          (XPU stability)
+      train.gradient_accumulation_steps = 2
+      train.gradient_checkpointing = true   (REQUIRED at [384,672]+; measured OOM without)
+      cache.use_cache = true                (REQUIRED at 32GB; live encode crashes)
+      lora.r = 16  (8-32 freely adjustable; memory-neutral at this LoRA scale)
+      optimizer = Adam8bit  (memory-neutral at 24M params; 30% faster step vs torch Adam)
+
+Usage:
+    python templates/probe_hw.py | python templates/recommend_config.py
+    python templates/recommend_config.py --probe probe.json --out config.yaml
+    python templates/recommend_config.py --probe probe.json --dataset-path <path/to/dataset>
+
+Output: a complete training YAML on stdout (or --out file). Selected §7
+catalog patterns printed to stderr as a comment list.
+
+The user must fill in remaining TODO placeholders before training:
+- model.pretrained_model_name_or_path
+- model.transformer_path       (optional: pre-quantized NF4 dir; omit to use online NF4 — memory-equivalent, slightly slower startup)
+- model.text_encoder_path      (emitted only for ram_gb <= 32; optional: pre-quantized NF4 text_encoder from §7.2)
+- data.init_args.dataset_path  (or pass --dataset-path)
+- logging.output_dir
+- cache.cache_dir
+
+Network policy: this script does NOT touch the network. All inputs are local.
+"""
+import argparse
+import json
+import sys
+
+
+def recommend(probe: dict, dataset_path: str | None = None) -> tuple[dict, list[str]]:
+    """Return (config_dict, selected_patterns_list).
+
+    This skill is NF4-QLoRA-only: NF4 transformer + bnb Adam8bit are
+    always emitted. RAM tier (system memory; iGPUs share unified RAM)
+    only gates the optional NF4 text_encoder layer (§7.2) and is
+    informational for the agent.
+
+    Resolution defaults to [384, 672] across all tiers — this is the only
+    value characterized in practice. Higher / lower resolutions may fit
+    different VRAM budgets but the trade-offs have not been measured.
+    """
+    ram_gb = probe.get("ram_gb", -1.0)
+
+    # NF4 transformer + Adam8bit: always-on for this skill's NF4 QLoRA recipe.
+    use_nf4_transformer = True
+    use_adam8bit = True
+    # NF4 text_encoder is the one tier-dependent optimization.
+    use_nf4_text_encoder_recommended = (ram_gb > 0 and ram_gb <= 32)
+
+    target_size = [384, 672]
+    controls_size = [[384, 672], [512, 512]]
+
+    use_grad_ckpt = True
+
+    patterns = []
+    if use_nf4_transformer:
+        patterns.append("§7.1 Pre-quantize transformer (NF4)")
+        patterns.append("§6.6 NF4 QLoRA patches (A1 + A2; apply before training)")
+    if use_nf4_text_encoder_recommended:
+        patterns.append("§7.2 Pre-quantize text_encoder (recommended for 32 GB machines — see §7.2)")
+    patterns.append("§7.3 Mode-aware loading")
+    patterns.append("§7.4 Cache-first workflow")
+    patterns.append("§5.1 YAML config patterns (this script's output applies them)")
+
+    cfg = {
+        "trainer": "QwenImageEdit",
+        "model": {
+            "pretrained_model_name_or_path": "<TODO: original Qwen-Image-Edit pipeline dir>",
+            "quantize": False,
+            "lora": {
+                "r": 16,
+                "lora_alpha": 16,
+                "init_lora_weights": "gaussian",
+                "target_modules": ["to_k", "to_q", "to_v", "to_out.0"],
+                "pretrained_weight": None,
+            },
+        },
+        "data": {
+            "class_path": "qflux.data.dataset.ImageDataset",
+            "init_args": {
+                "dataset_path": dataset_path if dataset_path else "<TODO: dataset path; see SKILL.md §3>",
+                "caption_dropout_rate": 0.05,
+                "prompt_image_dropout_rate": 0.05,
+                "selected_control_indexes": [1],
+                "cache_dir": "${cache.cache_dir}",
+                "use_cache": "${cache.use_cache}",
+                "processor": {
+                    "class_path": "qflux.data.preprocess.ImageProcessor",
+                    "init_args": {
+                        "process_type": "center_crop",
+                        "target_size": target_size,
+                        "controls_size": controls_size,
+                    },
+                },
+            },
+            "batch_size": 1,
+            "num_workers": 1,
+            "shuffle": True,
+        },
+        "logging": {
+            "output_dir": "<TODO: outputs/<run_name>>",
+            "report_to": "tensorboard",
+            "tracker_project_name": "<TODO: run name>",
+        },
+        "lr_scheduler": {
+            "scheduler_type": "cosine",
+            "warmup_steps": 50,
+            "num_cycles": 0.5,
+            "power": 1.0,
+        },
+        "train": {
+            "gradient_accumulation_steps": 2,
+            "max_train_steps": 1000,
+            "num_epochs": 100,
+            "checkpointing_steps": 100,
+            "checkpoints_total_limit": 10,
+            "max_grad_norm": 1.0,
+            "mixed_precision": "no",
+            "gradient_checkpointing": use_grad_ckpt,
+            "low_memory": True,
+        },
+        "cache": {
+            "devices": {"vae": "xpu:0", "text_encoder": "xpu:0"},
+            "cache_dir": "<TODO: outputs/<run_name>/cache>",
+            "use_cache": True,
+        },
+        "predict": {
+            "devices": {"vae": "xpu:0", "text_encoder": "xpu:0", "dit": "xpu:0"},
+        },
+        "resume": None,
+        "validation": {"enabled": False},
+    }
+
+    # NF4 + Adam8bit are always emitted (skill scope is NF4 QLoRA only).
+    cfg["model"]["transformer_path"] = "<TODO: pre-quantized NF4 dir from §7.1>"
+    if use_nf4_text_encoder_recommended:
+        cfg["model"]["text_encoder_path"] = "<TODO: pre-quantized NF4 text_encoder dir from §7.2>"
+    cfg["model"]["quantize_type"] = "nf4"
+    cfg["optimizer"] = {
+        "class_path": "bitsandbytes.optim.Adam8bit",
+        "init_args": {"lr": 0.0001, "betas": [0.9, 0.999]},
+    }
+
+    return cfg, patterns
+
+
+def _format_scalar(v) -> str:
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, str):
+        # Quote strings that look like config-vars, paths, or contain special chars
+        if (v.startswith("${") or v.startswith("<") or "/" in v or " " in v
+                or ":" in v or v == "no" or v == "yes" or v == "null"):
+            return f'"{v}"'
+        return v
+    return str(v)
+
+
+def _to_yaml(obj, indent: int = 0) -> str:
+    """Minimal YAML serializer. Sufficient for the schema we emit."""
+    sp = "  " * indent
+    if isinstance(obj, dict):
+        if not obj:
+            return f"{sp}{{}}"
+        lines = []
+        for k, v in obj.items():
+            if isinstance(v, dict) and v:
+                lines.append(f"{sp}{k}:")
+                lines.append(_to_yaml(v, indent + 1))
+            elif isinstance(v, list) and v and any(isinstance(x, (dict,)) for x in v):
+                lines.append(f"{sp}{k}:")
+                lines.append(_to_yaml(v, indent + 1))
+            elif isinstance(v, list):
+                # Inline scalar list (or list of lists)
+                if all(isinstance(x, list) for x in v):
+                    inner = ", ".join(
+                        "[" + ", ".join(_format_scalar(y) for y in x) + "]" for x in v
+                    )
+                    lines.append(f"{sp}{k}: [{inner}]")
+                else:
+                    inner = ", ".join(_format_scalar(x) for x in v)
+                    lines.append(f"{sp}{k}: [{inner}]")
+            else:
+                lines.append(f"{sp}{k}: {_format_scalar(v)}")
+        return "\n".join(lines)
+    elif isinstance(obj, list):
+        lines = []
+        for x in obj:
+            if isinstance(x, dict):
+                lines.append(f"{sp}-")
+                lines.append(_to_yaml(x, indent + 1))
+            else:
+                lines.append(f"{sp}- {_format_scalar(x)}")
+        return "\n".join(lines)
+    else:
+        return f"{sp}{_format_scalar(obj)}"
+
+
+def to_yaml(obj) -> str:
+    """Serialize to YAML. Prefer pyyaml when available; fall back to manual."""
+    try:
+        import yaml
+        return yaml.safe_dump(obj, sort_keys=False, default_flow_style=None,
+                              allow_unicode=True).rstrip() + "\n"
+    except ImportError:
+        return _to_yaml(obj) + "\n"
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Recommend a training config given hardware probe output."
+    )
+    p.add_argument("--probe",
+                   help="Path to probe JSON file (default: read stdin)")
+    p.add_argument("--out",
+                   help="Path to write YAML (default: stdout)")
+    p.add_argument("--dataset-path", default=None,
+                   help="Dataset path; embedded into output (default: TODO placeholder)")
+    args = p.parse_args()
+
+    if args.probe:
+        with open(args.probe) as f:
+            probe = json.load(f)
+    else:
+        probe = json.load(sys.stdin)
+
+    cfg, patterns = recommend(probe, dataset_path=args.dataset_path)
+    yaml_text = to_yaml(cfg)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(yaml_text)
+    else:
+        sys.stdout.write(yaml_text)
+
+    print("\n# Selected §7 catalog patterns to apply:", file=sys.stderr)
+    for pat in patterns:
+        print(f"#  - {pat}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a agent skill to `.claude/skills/qwen-image-edit-aipc-finetune/` that enables an AI agent to guide users through end-to-end QLoRA fine-tuning of Qwen-Image-Edit on Intel AI PC with Core Ultra processor on Windows:

 **What the skill covers**:
- Pre-flight prerequisites on Intel XPU
- Dataset preparation, XPU environment setup, hardware probe, and recommended config generation
- XPU framework adaptation (CUDA → Intel XPU wrappers)
- NF4 QLoRA memory optimizations (pre-quantized transformer + text encoder)
- Two-phase training (cache build + LoRA fit)
- Post-training visual comparison (base vs. LoRA)
- Troubleshooting
- etc.

**Files added**:
- `SKILL.md` — agent runbook (11 sections)
- `templates/` — Python scripts and Windows .bat launchers
- `README.md` — overview for human readers

@renerj

## Summary by Sourcery

Add a new agent skill that guides agents through end-to-end NF4 QLoRA fine-tuning of Qwen-Image-Edit on Intel AI PCs, including environment setup, hardware-aware config generation, dataset validation, training, and evaluation workflows.

New Features:
- Introduce an agent-oriented SKILL runbook for fine-tuning Qwen-Image-Edit with NF4 QLoRA on Intel AI PC (Core Ultra, Windows).
- Add Python utilities to probe local hardware, recommend a matching training configuration, validate datasets, pre-quantize model components to NF4, run visual inference comparisons, and monitor XPU memory usage.
- Provide Windows batch launchers that wrap oneAPI and conda activation for NF4 quantization and training runs on XPU.
- Document the templates and quick-start instructions for using the new skill and scripts within the qwen-image-finetune workflow.

Enhancements:
- Encapsulate hardware-aware and memory-optimized training practices for Intel XPU into reusable scripts and configs, reducing manual setup and tuning effort for Qwen-Image-Edit fine-tuning.